### PR TITLE
[JENKINS-34070] Better handle mismatched types

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableParameter.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableParameter.java
@@ -181,6 +181,8 @@ public final class DescribableParameter {
                 if (!(x.getCause() instanceof NoStaplerConstructorException)) {
                     LOGGER.log(Level.WARNING, "failed to uncoerce " + o, x);
                 }
+            } catch (NoStaplerConstructorException x) {
+                // leave it raw
             }
         }
         return o;

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -31,6 +31,7 @@ import hudson.model.Descriptor;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserMergeOptions;
 import hudson.plugins.git.extensions.impl.CleanBeforeCheckout;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.junit.BeforeClass;
@@ -54,6 +55,7 @@ import java.util.logging.Logger;
 
 import static org.jenkinsci.plugins.structs.describable.DescribableModel.*;
 import static org.junit.Assert.*;
+import org.junit.Ignore;
 
 @SuppressWarnings("unchecked") // generic array construction
 public class DescribableModelTest {
@@ -590,6 +592,12 @@ public class DescribableModelTest {
             "doGenerateSubmoduleConfigurations", false,
             "submoduleCfg", Collections.emptyList(),
             "userRemoteConfigs", Collections.emptyList()));
+    }
+
+    @Ignore("TODO mismatched types (String vs. enum), fails to uninstantiate mergeStrategy correctly")
+    @Issue("JENKINS-34070")
+    @Test public void userMergeOptions() throws Exception {
+        roundTrip(UserMergeOptions.class, map("mergeRemote", "x", "mergeTarget", "y", "mergeStrategy", "OCTOPUS", "fastForwardMode", "FF_ONLY"), "UserMergeOptions{mergeRemote='x', mergeTarget='y', mergeStrategy='OCTOPUS', fastForwardMode='--ff-only'}");
     }
 
     @Issue("JENKINS-32925") // but Base3/Base4 usages are the more realistic case


### PR DESCRIPTION
[JENKINS-34070](https://issues.jenkins-ci.org/browse/JENKINS-34070)

Prior to fix, the test would fail with a misleading error:

```
org.kohsuke.stapler.NoStaplerConstructorException: There's no @DataBoundConstructor on any constructor of class org.jenkinsci.plugins.gitclient.MergeCommand$Strategy
	at org.kohsuke.stapler.ClassDescriptor.loadConstructorParamNames(ClassDescriptor.java:177)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.<init>(DescribableModel.java:114)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.of(DescribableModel.java:100)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate__(DescribableModel.java:477)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate_(DescribableModel.java:474)
	at org.jenkinsci.plugins.structs.describable.DescribableParameter.uncoerce(DescribableParameter.java:174)
	at org.jenkinsci.plugins.structs.describable.DescribableParameter.inspect(DescribableParameter.java:122)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate(DescribableModel.java:435)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate__(DescribableModel.java:477)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate_(DescribableModel.java:474)
	at org.jenkinsci.plugins.structs.describable.DescribableModelTest.roundTrip(DescribableModelTest.java:636)
	at org.jenkinsci.plugins.structs.describable.DescribableModelTest.userMergeOptions(DescribableModelTest.java:600)
```

Now it will still fail, but only with incorrect output:

    expected:<{fastForwardMode=FF_ONLY, mergeRemote=x, mergeStrategy=OCTOPUS, mergeTarget=y}> but was:<{fastForwardMode=FF_ONLY, mergeRemote=x, mergeStrategy=default, mergeTarget=y}>

after printing a warning that more accurately represents what is wrong in the signature of `UserMergeOptions`:

```
WARNING: Cannot create control version of class hudson.plugins.git.UserMergeOptions using {fastForwardMode=FF_ONLY, mergeRemote=x, mergeStrategy=default, mergeTarget=y}
java.lang.ClassCastException: hudson.plugins.git.UserMergeOptions.mergeStrategy expects class java.lang.String but received class org.jenkinsci.plugins.gitclient.MergeCommand$Strategy
	at org.jenkinsci.plugins.structs.describable.DescribableModel.coerce(DescribableModel.java:326)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.buildArguments(DescribableModel.java:257)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.instantiate(DescribableModel.java:201)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate(DescribableModel.java:449)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate__(DescribableModel.java:477)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate_(DescribableModel.java:474)
	at org.jenkinsci.plugins.structs.describable.DescribableModelTest.roundTrip(DescribableModelTest.java:636)
	at org.jenkinsci.plugins.structs.describable.DescribableModelTest.userMergeOptions(DescribableModelTest.java:600)
```

@reviewbybees