### PR TITLE
[JENKINS-37400] Define ConstSymbol defining symbols for constant values

### DIFF
--- a/annotation/src/main/java/org/jenkinsci/ConstSymbol.java
+++ b/annotation/src/main/java/org/jenkinsci/ConstSymbol.java
@@ -1,0 +1,23 @@
+package org.jenkinsci;
+
+import org.jvnet.hudson.annotation_indexer.Indexed;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Defines a unique identifier to refer to an constant value
+ *
+ * @since TODO
+ */
+@Indexed
+@Retention(RUNTIME)
+@Target({FIELD})
+@Documented
+public @interface ConstSymbol {
+    String[] value();
+}

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -362,6 +362,8 @@ public final class DescribableModel<T> implements Serializable {
             return null;
         } else if (o instanceof UninstantiatedDescribable) {
             return ((UninstantiatedDescribable)o).instantiate(erased);
+        } else if (o instanceof UninstantiatedConstant) {
+            return ((UninstantiatedConstant)o).instantiate(erased);
         } else if (o instanceof Map) {
             Map<String,Object> m = new HashMap<String,Object>();
             for (Map.Entry<?,?> entry : ((Map<?,?>) o).entrySet()) {

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedConstant.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedConstant.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.structs.describable;
+
+import java.io.Serializable;
+
+import org.jenkinsci.plugins.structs.SymbolLookup;
+
+import groovy.lang.MissingPropertyException;
+
+/**
+ * Wraps a constant value to evaluate later
+ *
+ * @since TODO
+ */
+public class UninstantiatedConstant implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+
+    /**
+     * ctor
+     *
+     * @param name name of the constant value
+     */
+    public UninstantiatedConstant(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return name of the constant value
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Return a constant value determined in the current context
+     *
+     * @param base class determined in the current context
+     * @param <T> class determined in the current context
+     * @return a constant value
+     * @throws MissingPropertyException when no appropreate constant value if found
+     */
+    public <T> T instantiate(Class<T> base) throws MissingPropertyException {
+        T candidate = SymbolLookup.get().findConst(base, getName());
+        if (candidate != null) {
+            return candidate;
+        }
+
+        if (base.isEnum()) {
+            for (T enumValue: base.getEnumConstants()) {
+                if (((Enum<?>)enumValue).name().equals(getName())) {
+                    return enumValue;
+                }
+            }
+        }
+
+        throw new MissingPropertyException(String.format(
+            "No such property: %s",
+            getName()
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UninstantiatedConstant that = (UninstantiatedConstant) o;
+
+        if ((name != null) ? !name.equals(that.name) : (that.name != null)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return (name != null) ? name.hashCode() : 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("UninstantiatedConstant(%s)", getName());
+   }
+}

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.structs;
 
 import hudson.model.Descriptor;
+
+import org.jenkinsci.ConstSymbol;
 import org.jenkinsci.Symbol;
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,5 +62,42 @@ public class SymbolLookupTest {
     public void descriptorLookup() {
         assertThat(lookup.findDescriptor(Fishing.class, "net"), is(sameInstance((Descriptor)fishingNetDescriptor)));
         assertThat(lookup.findDescriptor(Tech.class, "net"),    is(sameInstance((Descriptor)internetDescriptor)));
+    }
+
+    public static class EnumLikeValue {
+        final private String value;
+
+        public EnumLikeValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @ConstSymbol({"YES", "yes"})
+        public static final EnumLikeValue YES = new EnumLikeValue("YES");
+
+        public static final EnumLikeValue NO = new EnumLikeValue("NO");
+    }
+
+    public static enum EnumValue {
+        @ConstSymbol("yes")
+        YES,
+        @ConstSymbol("NO")
+        NO,
+    }
+
+    @Test
+    public void findConst() throws Exception {
+        assertThat(lookup.findConst(EnumLikeValue.class, "YES"), is(sameInstance(EnumLikeValue.YES)));
+        assertThat(lookup.findConst(EnumLikeValue.class, "yes"), is(sameInstance(EnumLikeValue.YES)));
+        assertThat(lookup.findConst(EnumValue.class, "yes"), is(sameInstance(EnumValue.YES)));
+    }
+
+    @Test
+    public void findConstNotFound() throws Exception {
+        assertNull(lookup.findConst(EnumLikeValue.class, "NO"));
+        assertNull(lookup.findConst(EnumValue.class, "YES"));
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
@@ -99,5 +99,6 @@ public class SymbolLookupTest {
     public void findConstNotFound() throws Exception {
         assertNull(lookup.findConst(EnumLikeValue.class, "NO"));
         assertNull(lookup.findConst(EnumValue.class, "YES"));
+        assertNull(lookup.findConst(Object.class, "yes"));
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -24,6 +24,8 @@
 package org.jenkinsci.plugins.structs.describable;
 
 import com.google.common.collect.ImmutableMap;
+
+import groovy.lang.MissingPropertyException;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.BooleanParameterValue;
@@ -753,7 +755,6 @@ public class DescribableModelTest {
         }
     }
 
-
     @Test
     public void instantiateWithEnumLikeValue() throws Exception {
         assertEquals(
@@ -795,5 +796,16 @@ public class DescribableModelTest {
         public String toString() {
             return String.format("WithEnumLikeValue:%s/%s", value1, value2);
         }
+    }
+
+    @Test(expected=MissingPropertyException.class)
+    public void instantiateWithUnknownEnumValue() throws Exception {
+        instantiate(
+            WithEnumValue.class,
+            map(
+                "value1", new UninstantiatedConstant("NONE"),
+                "value2", new UninstantiatedConstant("TWO")
+            )
+        );
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -34,6 +34,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserMergeOptions;
 import hudson.plugins.git.extensions.impl.CleanBeforeCheckout;
 import org.codehaus.groovy.runtime.GStringImpl;
+import org.jenkinsci.ConstSymbol;
 import org.jenkinsci.plugins.structs.Fishing;
 import org.jenkinsci.plugins.structs.FishingNet;
 import org.jenkinsci.plugins.structs.Internet;
@@ -717,5 +718,82 @@ public class DescribableModelTest {
 
     private static void schema(Class<?> c, String schema) throws Exception {
         assertEquals(schema, new DescribableModel(c).toString());
+    }
+
+    @Test
+    public void instantiateWithEnumValue() throws Exception {
+        assertEquals(
+            "WithEnumValue:ONE/TWO",
+            instantiate(
+                WithEnumValue.class,
+                map(
+                    "value1", new UninstantiatedConstant("ONE"),
+                    "value2", new UninstantiatedConstant("TWO")
+                )
+            ).toString()
+        );
+    }
+
+    public static final class WithEnumValue {
+        public static enum Values {
+            ONE,
+            TWO,
+        }
+        private final Values value1;
+        @DataBoundSetter
+        private Values value2;
+
+        @DataBoundConstructor
+        public WithEnumValue(Values value1) {
+            this.value1 = value1;
+        }
+        @Override
+        public String toString() {
+            return String.format("WithEnumValue:%s/%s", value1, value2);
+        }
+    }
+
+
+    @Test
+    public void instantiateWithEnumLikeValue() throws Exception {
+        assertEquals(
+            "WithEnumLikeValue:one/two",
+            instantiate(
+                WithEnumLikeValue.class,
+                map(
+                    "value1", new UninstantiatedConstant("One"),
+                    "value2", new UninstantiatedConstant("Two")
+                )
+            ).toString()
+        );
+    }
+
+    public static final class WithEnumLikeValue {
+        public static class Values {
+            private final String value;
+            public Values(String value) {
+                this.value = value;
+            }
+            @ConstSymbol("One")
+            public static final Values ONE = new Values("one");
+            @ConstSymbol("Two")
+            public static final Values TWO = new Values("two");
+            @Override
+            public String toString() {
+                return value;
+            }
+        }
+        private final Values value1;
+        @DataBoundSetter
+        private Values value2;
+
+        @DataBoundConstructor
+        public WithEnumLikeValue(Values value1) {
+            this.value1 = value1;
+        }
+        @Override
+        public String toString() {
+            return String.format("WithEnumLikeValue:%s/%s", value1, value2);
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-37400](https://issues.jenkins-ci.org/browse/JENKINS-37400)

I want to use constant values in workflow-cps like
```
def runWrapper = selectRun job: 'upstream-project-name', 
  selector: status(SUCCESSFUL)
```

Background: jenkinsci/run-selector-plugin#12, jenkinsci/run-selector-plugin#14
I can use string values for enum type parameters like:
```
def runWrapper = selectRun job: 'upstream-project-name', 
  selector: status('SUCCESSFUL')
```

But rules for string values and constant values are often different:
* Starting with a lower-case letter are preferred for string values. (e.g. 'lastSuccessful' for permalink)
* Using upper-case letters are preferred for constant values (Java coding practice)

This issue looks come from passing names of constant variables as strings.
Allowing to use names of constant variables as symbols in scripts resolves this issue.

Outline of this change:
* Introduce `ConstSymbl` annotation to define symbols for constants variables.
    * You don't need to annotate enum constants if you use their names as symbols. You have to annotate enum constants only when you want to define aliases.
    * You can annotate `static final` variables to define their symbols. It is useful for enum-like classes like `hudson.model.Result` (`Result.SUCCESS`, `Result.FAILURE`).
* Introduce `UninstantiatedConstant` which carries constant names and resolves to constant values later when its type is decided.
    * DSLs like workflow-cps is expected to pass unknown variable symbols as `UninstantiatedConstant`.
