### PR TITLE
allow use of @Symbol on methods

### DIFF
--- a/annotation/src/main/java/org/jenkinsci/Symbol.java
+++ b/annotation/src/main/java/org/jenkinsci/Symbol.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  */
 @Indexed
 @Retention(RUNTIME)
-@Target({TYPE})
+@Target({TYPE, METHOD})
 @Documented
 public @interface Symbol {
     String[] value();


### PR DESCRIPTION
allow use of @Symbol on property setters.
a DSL might want to reflect labels end-user use to read on web UI, but the actual property has a distinct name. For sample Jenkins#labelString is `label` on UI. Using @Symbol on `setLabelString` allows the DSL executor to find matching accessor.
 