### PR TITLE
SymbolLookup.getSymbolValue(Class) Javadoc appears to have been incorrect

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
@@ -174,8 +174,8 @@ public class SymbolLookup {
     }
 
     /**
-     * Get the {@link Symbol} value(s) for the given class, if the annotation is present. Unlike {@link #getSymbolValue(Object)},
-     * this will not get the {@link Descriptor} for {@link Describable} classes.
+     * Get the {@link Symbol} value(s) for the given class, if the annotation is present.
+     * This will get the {@link Descriptor} for {@link Describable} classes.
      *
      * @param c A class.
      * @return The {@link Symbol} annotation value(s) for the given class, or an empty {@link Set} if the annotation is not present.


### PR DESCRIPTION
As far as I can make out, some of the Javadoc added in #10 did not get updated in response to changes in the implementation.

@reviewbybees