### PR TITLE
[FIX JENKINS-46122] Report base class name when symbol couldn't be resolved

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -445,7 +445,7 @@ public final class DescribableModel<T> implements Serializable {
                     }
                 }
             }
-            throw new UnsupportedOperationException("Undefined symbol ‘" + symbol + "’");
+            throw new UnsupportedOperationException("no known implementation of " + base + " is using symbol ‘" + symbol + "’");
         }
 
         if (Modifier.isAbstract(base.getModifiers())) {

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/FishingRod.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/FishingRod.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.structs;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * "rod" symbol
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class FishingRod extends AbstractDescribableImpl<FishingRod> implements Fishing {
+    @DataBoundConstructor
+    public FishingRod() {
+    }
+
+
+    @Extension @Symbol("rod")
+    public static class DescriptorImpl extends Descriptor<FishingRod> {
+        @Override
+        public String getDisplayName() {
+            return "fishing rod";
+        }
+    }
+}

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -676,6 +676,17 @@ public class DescribableModelTest {
         assertEquals(Internet.class, DescribableModel.resolveClass(Tech.class, "Internet", null));
     }
 
+    @Issue("JENKINS-46122")
+    @Test
+    public void resolveSymbolOnWrongBaseClass() throws Exception {
+        try {
+            DescribableModel.resolveClass(Tech.class, null, "rod");
+            fail("No symbol for Tech should exist.");
+        } catch (UnsupportedOperationException e) {
+            assertEquals("no known implementation of " + Tech.class + " is using symbol ‘rod’", e.getMessage());
+        }
+    }
+
     @Test
     public void singleRequiredParameter() throws Exception {
         // positive case


### PR DESCRIPTION
@reviewbybees 
/cc @carlossg 

This reports the base class name when failing to look up a symbol, which can be confusing for developer in case the base class is not what is expected.