### PR TITLE
Optimize memory use

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -155,6 +155,7 @@ public final class DescribableModel<T> implements Serializable {
         if (parameters.size() == 1) {
             Map.Entry<String, DescribableParameter> entry = parameters.entrySet().iterator().next();
             parameters = Collections.singletonMap(entry.getKey(), entry.getValue());
+            parametersView = parameters;
         } else {
             // Shrink down HashMap to reduce memory use, at the cost of an extra copy cycle
             parameters = new LinkedHashMap<String, DescribableParameter>(parameters);
@@ -600,7 +601,6 @@ public final class DescribableModel<T> implements Serializable {
                 }
             }
         }
-
         UninstantiatedDescribable ud = new UninstantiatedDescribable(symbolOf(o), null, r);
         ud.setModel(this);
         return ud;

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableParameter.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableParameter.java
@@ -178,14 +178,14 @@ public final class DescribableParameter {
         } else if ((type == Character.class || type == char.class) && o instanceof Character) {
             return o.toString();
         } else if (o instanceof Object[]) {
-            List<Object> list = new ArrayList<Object>();
             Object[] array = (Object[]) o;
+            List<Object> list = new ArrayList<Object>(array.length);
             for (Object elt : array) {
                 list.add(uncoerce(elt, array.getClass().getComponentType()));
             }
             return list;
         } else if (o instanceof Collection && Types.isSubClassOf(type, Collection.class)) {
-            List<Object> list = new ArrayList<Object>();
+            List<Object> list = new ArrayList<Object>(((Collection) o).size());
             for (Object elt : (Collection<?>) o) {
                 list.add(uncoerce(elt, Types.getTypeArgument(Types.getBaseClass(type,Collection.class),0,Object.class)));
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -6,6 +6,7 @@ import org.jenkinsci.Symbol;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -111,7 +112,7 @@ public class UninstantiatedDescribable implements Serializable {
             // see DescribableParameter.uncoerce for possible variety
             v = toMap(v);
             if (v instanceof List) {
-                List l = new ArrayList();
+                List l = new ArrayList(((List) v).size());
                 for (Object o : (List) v) {
                     l.add(toMap(o));
                 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -27,7 +27,12 @@ public class UninstantiatedDescribable implements Serializable {
     public UninstantiatedDescribable(String symbol, String klass, Map<String, ?> arguments) {
         this.symbol = symbol;
         this.klass = klass;
-        this.arguments = arguments;
+        if (arguments.size() == 1) {
+            Entry<String, ?> entry = arguments.entrySet().iterator().next();
+            this.arguments = Collections.singletonMap(entry.getKey(), entry.getValue());
+        } else {
+            this.arguments = arguments;
+        }
     }
 
     public UninstantiatedDescribable(Map<String, ?> arguments) {


### PR DESCRIPTION
This shrinks down some oversize collections and uses a SingletonMap etc where possible to reduce the memory footprint of some of the Structs classes. 

Why?  Well, we tend to carry around a LOT of `UninstantiatedDescribable`s (and their associated `DescribableModel` baggage) due to many Pipeline FlowNodes having ArgumentsActionImpls with a list of arguments including UninstantiatedDescribables. 

I noted in heap dumps that each ArgumentsActionImpl carried a weight of several kB due to data structures - for something usually carrying a very tiny structure with maybe 1 or 2 parameters.

Not much if you have 1 or two of them, but if you have hundreds of thousands (what I observed) or maybe even millions (on busy systems)  that adds up rather quickly!