### PR TITLE
Fix Groovy invocation awfulness breaking with Collections.singletonMap vs. LinkedHashMap

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -172,16 +172,7 @@ public final class DescribableModel<T> implements Serializable {
             }
         }
         parameters.putAll(rest);
-
-        if (parameters.size() == 1) {
-            Map.Entry<String, DescribableParameter> entry = parameters.entrySet().iterator().next();
-            parameters = Collections.singletonMap(entry.getKey(), entry.getValue());
-            parametersView = parameters;
-        } else {
-            // Shrink down HashMap to reduce memory use, at the cost of an extra copy cycle
-            parameters = new LinkedHashMap<String, DescribableParameter>(parameters);
-            parametersView = Collections.unmodifiableMap(parameters);
-        }
+        parametersView = Collections.unmodifiableMap(parameters);
         modelCache.putIfAbsent(clazz.getName(), this);
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -27,12 +27,7 @@ public class UninstantiatedDescribable implements Serializable {
     public UninstantiatedDescribable(String symbol, String klass, Map<String, ?> arguments) {
         this.symbol = symbol;
         this.klass = klass;
-        if (arguments.size() == 1) {
-            Entry<String, ?> entry = arguments.entrySet().iterator().next();
-            this.arguments = Collections.singletonMap(entry.getKey(), entry.getValue());
-        } else {
-            this.arguments = arguments;
-        }
+        this.arguments = arguments;
     }
 
     public UninstantiatedDescribable(Map<String, ?> arguments) {


### PR DESCRIPTION
Yes, it's borderline insane but https://github.com/jenkinsci/structs-plugin/pull/29 completely hoses a Declarative run due to... sigh, groovy method resolution probably.  Sample error below. 

> org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
General error during semantic analysis: Cannot cast object '[strategy: BuildDiscarder{LogRotator(daysToKeepStr: String, numToKeepStr: String, artifactDaysToKeepStr: String, artifactNumToKeepStr: String)}]' with class 'java.util.LinkedHashSet' to class 'java.util.List' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.util.List(org.jenkinsci.plugins.structs.describable.DescribableParameter)

> org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '[strategy: BuildDiscarder{LogRotator(daysToKeepStr: String, numToKeepStr: String, artifactDaysToKeepStr: String, artifactNumToKeepStr: String)}]' with class 'java.util.LinkedHashSet' to class 'java.util.List' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.util.List(org.jenkinsci.plugins.structs.describable.DescribableParameter)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnSAM(DefaultTypeTransformation.java:403)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnNumber(DefaultTypeTransformation.java:319)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnCollection(DefaultTypeTransformation.java:267)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:219)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.castToType(ScriptBytecodeAdapter.java:603)
	at org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidatorImpl.validateElement(ModelValidatorImpl.groovy:459)
	at org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall.validate(ModelASTMethodCall.java:57)
	at org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption.validate(ModelASTOption.java:20)
	at org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions.validate(ModelASTOptions.java:37)
	at org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef.validate(ModelASTPipelineDef.java:81)
	at org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef$validate.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.ModelParser.parsePipelineStep(ModelParser.groovy:251)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.ModelParser.this$2$parsePipelineStep(ModelParser.groovy)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.ModelParser.parse(ModelParser.groovy:149)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.ModelParser$parse.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.ModelParser.parse(ModelParser.groovy:116)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.ModelParser.parse(ModelParser.groovy)
	at org.jenkinsci.plugins.pipeline.modeldefinition.parser.GroovyShellDecoratorImpl$1.call(GroovyShellDecoratorImpl.java:78)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1065)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:603)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:133)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:557)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:518)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:290)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:419)

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1085)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:603)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:133)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:557)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:518)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:290)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:419)
Finished: FAILURE