### PR TITLE
Allow coercion from String to numbers and booleans automatically

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>structs-parent</artifactId>
-    <version>1.15-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <groupId>org.jenkins-ci</groupId>
   <artifactId>symbol-annotation</artifactId>
-  <version>1.15-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
 
   <name>Symbol annotation</name>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>structs-parent</artifactId>
-    <version>1.15-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>structs</artifactId>
-  <version>1.15-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Structs Plugin</name>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.15-SNAPSHOT</version>
+      <version>${revision}${changelist}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -408,6 +408,16 @@ public final class DescribableModel<T> implements Serializable {
             return Result.fromString((String)o);
         } else if (o instanceof String && (erased == char.class || erased == Character.class) && ((String) o).length() == 1) {
             return ((String) o).charAt(0);
+        } else if (o instanceof String && (erased == int.class || erased == Integer.class)) {
+            return Integer.valueOf((String)o);
+        } else if (o instanceof String && (erased == float.class || erased == Float.class)) {
+            return Float.valueOf((String)o);
+        } else if (o instanceof String && (erased == long.class || erased == Long.class)) {
+            return Long.valueOf((String)o);
+        } else if (o instanceof String && (erased == double.class || erased == Double.class)) {
+            return Double.valueOf((String)o);
+        } else if (o instanceof String && (erased == boolean.class || erased == Boolean.class)) {
+            return Boolean.valueOf((String)o);
         } else if (o instanceof List && erased.isArray()) {
             Class<?> componentType = erased.getComponentType();
             List<Object> list = coerceList(context, componentType, (List) o);

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -733,6 +733,14 @@ public class DescribableModelTest {
     }
 
     @Test
+    public void coerceNumbersAndBoolean() throws Exception {
+        IntAndBool intAndBool = (IntAndBool) new UninstantiatedDescribable("intAndBool", null,
+                ImmutableMap.<String, Object>of("i", "5", "b", "true")).instantiate();
+        assertEquals(5, intAndBool.i);
+        assertEquals(true, intAndBool.b);
+    }
+
+    @Test
     public void serialization() {
         LoneStar s = new LoneStar("texas");
         DescribableModel<LoneStar> m = DescribableModel.of(LoneStar.class);

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/IntAndBool.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/IntAndBool.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.structs.describable;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Testing coercion of strings to numbers and booleans
+ *
+ * @author Andrew Bayer
+ */
+public class IntAndBool extends AbstractDescribableImpl<IntAndBool> {
+    public int i;
+    public boolean b;
+
+    @DataBoundConstructor
+    public IntAndBool(int i) {
+        this.i = i;
+    }
+
+    // can have optional parameters
+    @DataBoundSetter
+    public void setB(boolean b) {
+        this.b = b;
+    }
+
+    @Extension
+    @Symbol("intAndBool")
+    public static class DescriptorImpl extends Descriptor<IntAndBool> {
+        @Override
+        public String getDisplayName() {
+            return "An integer and a boolean";
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>3.10</version>
     <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>structs-parent</artifactId>
-  <version>1.15-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>pom</packaging>
 
   <name>Structs: Parent</name>
@@ -31,10 +31,12 @@
     <connection>scm:git:git://github.com/jenkinsci/structs-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/structs-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/structs-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <properties>
+    <revision>1.15</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.7.3</jenkins.version>
     <java.level>7</java.level>
   </properties>


### PR DESCRIPTION
I'm working on something that involves parsing YAML and then doing
parameter substitution on the resulting map. I then take that map and
instantiate it via an `UninstantiatedDescribable`. But it's a giant
hassle to navigate the full map to figure out which cases where I've
substituted a parameter need to be coerced from a `String` to an
`int`, `Float`, `boolean`, etc. Since we already have special-case
handling of `URL` and `Result` here, why not do the same for some
other simple cases?

Also, I incrementalized while I was here.