### PR TITLE
(second attempt) Allow coercion from String to numbers and booleans automatically

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-7</version>
   </extension>
 </extensions>

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -409,7 +409,7 @@ public final class DescribableModel<T> implements Serializable {
             return Result.fromString((String)o);
         } else if (o instanceof String && (erased == char.class || erased == Character.class) && ((String) o).length() == 1) {
             return ((String) o).charAt(0);
-        } else if (o instanceof String && ClassUtils.isAssignable(erased, Number.class)) {
+        } else if (o instanceof String && ClassUtils.isAssignable(ClassUtils.primitiveToWrapper(erased), Number.class)) {
             return coerceStringToNumber(ClassUtils.primitiveToWrapper(erased), (String)o);
         } else if (o instanceof String && (erased == boolean.class || erased == Boolean.class)) {
             return Boolean.valueOf((String)o);

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -408,6 +408,16 @@ public final class DescribableModel<T> implements Serializable {
             return Result.fromString((String)o);
         } else if (o instanceof String && (erased == char.class || erased == Character.class) && ((String) o).length() == 1) {
             return ((String) o).charAt(0);
+        } else if (o instanceof String && (erased == int.class || erased == Integer.class)) {
+            return Integer.valueOf((String)o);
+        } else if (o instanceof String && (erased == float.class || erased == Float.class)) {
+            return Float.valueOf((String)o);
+        } else if (o instanceof String && (erased == long.class || erased == Long.class)) {
+            return Long.valueOf((String)o);
+        } else if (o instanceof String && (erased == double.class || erased == Double.class)) {
+            return Double.valueOf((String)o);
+        } else if (o instanceof String && (erased == boolean.class || erased == Boolean.class)) {
+            return Boolean.valueOf((String)o);
         } else if (o instanceof List && erased.isArray()) {
             Class<?> componentType = erased.getComponentType();
             List<Object> list = coerceList(context, componentType, (List) o);

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -410,7 +410,7 @@ public final class DescribableModel<T> implements Serializable {
         } else if (o instanceof String && (erased == char.class || erased == Character.class) && ((String) o).length() == 1) {
             return ((String) o).charAt(0);
         } else if (o instanceof String && ClassUtils.isAssignable(ClassUtils.primitiveToWrapper(erased), Number.class)) {
-            return coerceStringToNumber(ClassUtils.primitiveToWrapper(erased), (String)o);
+            return coerceStringToNumber(context, ClassUtils.primitiveToWrapper(erased), (String)o);
         } else if (o instanceof String && (erased == boolean.class || erased == Boolean.class)) {
             return Boolean.valueOf((String)o);
         } else if (o instanceof List && erased.isArray()) {
@@ -422,7 +422,8 @@ public final class DescribableModel<T> implements Serializable {
         }
     }
 
-    private Object coerceStringToNumber(@Nonnull Class numberClass, @Nonnull String o) throws ClassCastException {
+    private Object coerceStringToNumber(@Nonnull String context, @Nonnull Class numberClass, @Nonnull String o)
+            throws ClassCastException {
         try {
             if (numberClass.equals(Integer.class)) {
                 return Integer.valueOf(o);
@@ -441,7 +442,7 @@ public final class DescribableModel<T> implements Serializable {
                 return o;
             }
         } catch (NumberFormatException nfe) {
-            throw new ClassCastException(nfe.getMessage());
+            throw new ClassCastException(context + " expects " + numberClass + " but was unable to coerce the received value \"" + o + "\" to that type");
         }
     }
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -731,6 +731,14 @@ public class DescribableModelTest {
     }
 
     @Test
+    public void coerceNumbersAndBoolean() throws Exception {
+        IntAndBool intAndBool = (IntAndBool) new UninstantiatedDescribable("intAndBool", null,
+                ImmutableMap.<String, Object>of("i", "5", "b", "true")).instantiate();
+        assertEquals(5, intAndBool.i);
+        assertEquals(true, intAndBool.b);
+    }
+
+    @Test
     public void serialization() {
         LoneStar s = new LoneStar("texas");
         DescribableModel<LoneStar> m = DescribableModel.of(LoneStar.class);

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/IntAndBool.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/IntAndBool.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.structs.describable;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Testing coercion of strings to numbers and booleans
+ *
+ * @author Andrew Bayer
+ */
+public class IntAndBool extends AbstractDescribableImpl<IntAndBool> {
+    public int i;
+    public boolean b;
+
+    @DataBoundConstructor
+    public IntAndBool(int i) {
+        this.i = i;
+    }
+
+    // can have optional parameters
+    @DataBoundSetter
+    public void setB(boolean b) {
+        this.b = b;
+    }
+
+    @Extension
+    @Symbol("intAndBool")
+    public static class DescriptorImpl extends Descriptor<IntAndBool> {
+        @Override
+        public String getDisplayName() {
+            return "An integer and a boolean";
+        }
+    }
+}


### PR DESCRIPTION
I'm working on something that involves parsing YAML and then doing
parameter substitution on the resulting map. I then take that map and
instantiate it via an `UninstantiatedDescribable`. But it's a giant
hassle to navigate the full map to figure out which cases where I've
substituted a parameter need to be coerced from a `String` to an
`int`, `Float`, `boolean`, etc. Since we already have special-case
handling of `URL` and `Result` here, why not do the same for some
other simple cases?