### PR TITLE
[JENKINS-53825] Choose from ambiguous class names via a simple heuristic

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -50,6 +50,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable.*;
 
@@ -399,7 +400,7 @@ public final class DescribableModel<T> implements Serializable {
                 m.put((String) entry.getKey(), entry.getValue());
             }
 
-            Class<?> clazz = resolveClass(erased, (String) m.remove(CLAZZ), null);
+            Class<?> clazz = resolveClass(erased, (String) m.remove(CLAZZ), null, getType());
             return new DescribableModel(clazz).instantiate(m);
         } else if (o instanceof String && erased.isEnum()) {
             return Enum.valueOf(erased.asSubclass(Enum.class), (String) o);
@@ -456,7 +457,8 @@ public final class DescribableModel<T> implements Serializable {
      * @param base
      *      Signature of the type that the resolved class should be assignable to.
      */
-    /*package*/ static Class<?> resolveClass(Class<?> base, @Nullable String name, @Nullable String symbol) throws ClassNotFoundException {
+    /*package*/ static Class<?> resolveClass(Class<?> base, @Nullable String name, @Nullable String symbol,
+                                             @Nullable Class<?> contextClass) throws ClassNotFoundException {
         // TODO: if both name & symbol are present, should we verify its consistency?
 
         if (name != null) {
@@ -465,19 +467,43 @@ public final class DescribableModel<T> implements Serializable {
                 ClassLoader loader = j != null ? j.getPluginManager().uberClassLoader : Thread.currentThread().getContextClassLoader();
                 return Class.forName(name, true, loader);
             } else {
-                Class<?> clazz = null;
+                List<Class<?>> possibleClazzes = new ArrayList<>();
                 for (Class<?> c : findSubtypes(base)) {
                     if (c.getSimpleName().equals(name)) {
-                        if (clazz != null) {
-                            throw new UnsupportedOperationException(name + " as a " + base + " could mean either " + clazz.getName() + " or " + c.getName());
-                        }
-                        clazz = c;
+                        possibleClazzes.add(c);
                     }
                 }
-                if (clazz == null) {
+                if (possibleClazzes.isEmpty()) {
                     throw new UnsupportedOperationException("no known implementation of " + base + " is named " + name);
                 }
-                return clazz;
+                if (possibleClazzes.size() != 1) {
+                    // Try to heuristically determine the correct class.
+                    List<Class<?>> narrowedClazzes = new ArrayList<>();
+                    for (Class<?> possible : possibleClazzes) {
+                        if (contextClass != null) {
+                            if (contextClass.equals(possible.getEnclosingClass())
+                                    || contextClass.getPackage().equals(possible.getPackage())
+                                    || possible.getPackage().getName().startsWith(contextClass.getPackage().getName())) {
+                                narrowedClazzes.add(possible);
+                            }
+                        }
+                    }
+
+                    // We found just one that was eligible, return that.
+                    if (narrowedClazzes.size() == 1) {
+                        return narrowedClazzes.get(0);
+                    }
+
+                    // Couldn't heuristically determine the correct class, error out.
+                    String errorString;
+                    if (possibleClazzes.size() == 2) {
+                        errorString = possibleClazzes.stream().map(Class::getName).collect(Collectors.joining(" or "));
+                    } else {
+                        errorString = possibleClazzes.stream().map(Class::getName).collect(Collectors.joining(", "));
+                    }
+                    throw new UnsupportedOperationException(name + " as a " + base + " could mean any of " + errorString);
+                }
+                return possibleClazzes.get(0);
             }
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -164,7 +164,7 @@ public class UninstantiatedDescribable implements Serializable {
      *      depends on this parameter.
      */
     public <T> T instantiate(Class<T> base) throws Exception {
-        Class<?> c = DescribableModel.resolveClass(base, klass, symbol);
+        Class<?> c = DescribableModel.resolveClass(base, klass, symbol, null);
         return base.cast(new DescribableModel(c).instantiate(arguments));
     }
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AbstractSecondSharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AbstractSecondSharedName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,29 +24,7 @@
 
 package org.jenkinsci.plugins.structs.describable;
 
-import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import org.kohsuke.stapler.DataBoundConstructor;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
-
-    @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
-
-    @Override
-    public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
-    }
-
-    @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
-        @Override
-        public String getDisplayName() {
-                return "An unambiguous describable";
-            }
-    }
+public abstract class AbstractSecondSharedName extends AbstractDescribableImpl<AbstractSecondSharedName> {
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AbstractThirdSharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AbstractThirdSharedName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,29 +24,7 @@
 
 package org.jenkinsci.plugins.structs.describable;
 
-import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import org.kohsuke.stapler.DataBoundConstructor;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
-
-    @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
-
-    @Override
-    public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
-    }
-
-    @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
-        @Override
-        public String getDisplayName() {
-                return "An unambiguous describable";
-            }
-    }
+public abstract class AbstractThirdSharedName extends AbstractDescribableImpl<AbstractThirdSharedName> {
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/NarrowAmbiguousArrayContainer.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/NarrowAmbiguousArrayContainer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,31 +22,38 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.structs.describable;
+package org.jenkinsci.plugins.structs.describable.first;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
+import java.util.Arrays;
+
+public class NarrowAmbiguousArrayContainer extends AbstractDescribableImpl<NarrowAmbiguousArrayContainer> {
+    private final Describable<?>[] array;
 
     @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
+    public NarrowAmbiguousArrayContainer(Describable<?>... array) {
+        this.array = array.clone();
+    }
+
+    public Describable<?>[] getArray() {
+        return array.clone();
+    }
 
     @Override
     public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
+        return "NarrowAmbiguousArrayContainer[array[" + Arrays.asList(array).toString() + "]]";
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
+    public static class DescriptorImpl extends Descriptor<NarrowAmbiguousArrayContainer> {
         @Override
         public String getDisplayName() {
-                return "An unambiguous describable";
-            }
+            return "ambiguous array container";
+        }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/NarrowAmbiguousContainer.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/NarrowAmbiguousContainer.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.structs.describable.first;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import org.jenkinsci.plugins.structs.describable.AbstractSharedName;
+import org.jenkinsci.plugins.structs.describable.AbstractThirdSharedName;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class NarrowAmbiguousContainer extends AbstractDescribableImpl<NarrowAmbiguousContainer> {
+    public final Describable<?> ambiguous;
+    public final Describable<?> unambiguous;
+
+    @DataBoundConstructor
+    public NarrowAmbiguousContainer(Describable<?> ambiguous, Describable<?> unambiguous) {
+        this.ambiguous = ambiguous;
+        this.unambiguous = unambiguous;
+    }
+
+    @Override
+    public String toString() {
+        return "NarrowAmbiguousContainer[ambiguous[" + ambiguous.toString() + "], unambiguous[" + unambiguous.toString() + "]]";
+    }
+    @Extension
+    public static class DescriptorImpl extends Descriptor<NarrowAmbiguousContainer> {
+        @Override
+        public String getDisplayName() {
+            return "narrow ambiguous container";
+        }
+    }
+
+    public static class ThirdSharedName extends AbstractThirdSharedName {
+        private final String one;
+        private String two;
+
+        @DataBoundConstructor
+        public ThirdSharedName(String one) {
+            this.one = one;
+        }
+
+        public String getOne() {
+            return one;
+        }
+
+        public String getTwo() {
+            return two;
+        }
+
+        @DataBoundSetter
+        public void setTwo(String two) {
+            this.two = two;
+        }
+
+        public String getLegacyTwo() {
+            return two;
+        }
+
+        @Deprecated
+        @DataBoundSetter
+        public void setLegacyTwo(String two) {
+            this.two = two;
+        }
+
+        @Override
+        public String toString() {
+            return "ThirdSharedName[one[" + one + "], [two[" + two + "]]";
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<AbstractThirdSharedName> {
+            @Override
+            public String getDisplayName() {
+                return "inner.ThirdSharedName";
+            }
+        }
+    }
+}

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/NarrowAmbiguousListContainer.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/NarrowAmbiguousListContainer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,31 +22,35 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.structs.describable;
+package org.jenkinsci.plugins.structs.describable.first;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NarrowAmbiguousListContainer extends AbstractDescribableImpl<NarrowAmbiguousListContainer> {
+    public final List<Describable<?>> list;
 
     @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
+    public NarrowAmbiguousListContainer(List<Describable<?>> list) {
+        this.list = new ArrayList<>(list);
+    }
 
     @Override
     public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
+        return "NarrowAmbiguousListContainer[list[" + list + "]]";
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
+    public static class DescriptorImpl extends Descriptor<NarrowAmbiguousListContainer> {
         @Override
         public String getDisplayName() {
-                return "An unambiguous describable";
-            }
+            return "ambiguous list container";
+        }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/SharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/SharedName.java
@@ -63,7 +63,12 @@ public class SharedName extends AbstractSharedName {
         this.two = two;
     }
 
-    @Extension
+    @Override
+    public String toString() {
+        return "SharedName[one[" + one + "], [two[" + two + "]]";
+    }
+
+    @Extension(ordinal = 0)
     public static class DescriptorImpl extends Descriptor<AbstractSharedName> {
         @Override
         public String getDisplayName() {

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/second/SecondSharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/second/SecondSharedName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,31 +22,57 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.structs.describable;
+package org.jenkinsci.plugins.structs.describable.first.second;
 
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.jenkinsci.plugins.structs.describable.AbstractSecondSharedName;
+import org.jenkinsci.plugins.structs.describable.AbstractSharedName;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
+public class SecondSharedName extends AbstractSecondSharedName {
+    private final String one;
+    private String two;
 
     @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
+    public SecondSharedName(String one) {
+        this.one = one;
+    }
+
+    public String getOne() {
+        return one;
+    }
+
+    public String getTwo() {
+        return two;
+    }
+
+    @DataBoundSetter
+    public void setTwo(String two) {
+        this.two = two;
+    }
+
+    public String getLegacyTwo() {
+        return two;
+    }
+
+    @Deprecated
+    @DataBoundSetter
+    public void setLegacyTwo(String two) {
+        this.two = two;
+    }
 
     @Override
     public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
+        return "SecondSharedName[one[" + one + "], [two[" + two + "]]";
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
+    public static class DescriptorImpl extends Descriptor<AbstractSecondSharedName> {
         @Override
         public String getDisplayName() {
-                return "An unambiguous describable";
-            }
+            return "first.SecondSharedName";
+        }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/second/SharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/second/SharedName.java
@@ -38,7 +38,12 @@ public class SharedName extends AbstractSharedName {
         this.two = two;
     }
 
-    @Extension
+    @Override
+    public String toString() {
+        return "SharedName[two[" + two + "]]";
+    }
+
+    @Extension(ordinal = 1)
     public static class DescriptorImpl extends Descriptor<AbstractSharedName> {
         @Override
         public String getDisplayName() {

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/third/SecondSharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/third/SecondSharedName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,31 +22,32 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.structs.describable;
+package org.jenkinsci.plugins.structs.third;
 
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.jenkinsci.plugins.structs.describable.AbstractSecondSharedName;
+import org.jenkinsci.plugins.structs.describable.AbstractSharedName;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
+public class SecondSharedName extends AbstractSecondSharedName {
+    public final String two;
 
     @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
+    public SecondSharedName(String two) {
+        this.two = two;
+    }
 
     @Override
     public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
+        return "SecondSharedName[two[" + two + "]]";
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
+    public static class DescriptorImpl extends Descriptor<AbstractSharedName> {
         @Override
         public String getDisplayName() {
-                return "An unambiguous describable";
-            }
+            return "third.SecondSharedName";
+        }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/third/ThirdSharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/third/ThirdSharedName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,31 +22,32 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.structs.describable;
+package org.jenkinsci.plugins.structs.third;
 
 import hudson.Extension;
-import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.jenkinsci.plugins.structs.describable.AbstractThirdSharedName;
+import org.jenkinsci.plugins.structs.describable.AbstractSharedName;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
-    public final String one;
+public class ThirdSharedName extends AbstractThirdSharedName {
+    public final String two;
 
     @DataBoundConstructor
-    public UnambiguousClassName(String one) {
-            this.one = one;
-        }
+    public ThirdSharedName(String two) {
+        this.two = two;
+    }
 
     @Override
     public String toString() {
-        return "UnambiguousClassName[one[" + one + "]]";
+        return "ThirdSharedName[two[" + two + "]]";
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
+    public static class DescriptorImpl extends Descriptor<AbstractSharedName> {
         @Override
         public String getDisplayName() {
-                return "An unambiguous describable";
-            }
+            return "third.ThirdSharedName";
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-53825](https://issues.jenkins-ci.org/browse/JENKINS-53825)

If there are multiple possible classes matching a name on resolution,
filter for just classes that are either inner classes of the model
class, are in the same package as the model class, or are in
subpackages of the model class's package. If more than one class
passes those filters, we'll still fail.

Also starts reporting all possible clases when there are more than two
of them.