### PR TITLE
Attempting to analyze ChoiceParameterDefinition.choices just causes the world to explode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 **/*.iml
 .idea
+work

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -177,6 +177,10 @@ public final class DescribableModel<T> implements Serializable {
     }
 
     private void addParameter(Map<String,DescribableParameter> props, Type type, String name, Setter setter) {
+        if (type == Object.class) {
+            // For example, ChoiceParameterDefinition.choices is just not analyzable.
+            return;
+        }
         props.put(name, new DescribableParameter(this, type, name, setter));
     }
 


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/3014 breaks basic assumptions. Anything trying to create a model of something taking parameters (say, the `input` step) spins off into space analyzing _every `Describable` known_.