### PR TITLE
[JENKINS-53917] Reverting #41 as it broke binding of ChoiceParameterDefinition in scripts

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -177,10 +177,6 @@ public final class DescribableModel<T> implements Serializable {
     }
 
     private void addParameter(Map<String,DescribableParameter> props, Type type, String name, Setter setter) {
-        if (type == Object.class) {
-            // For example, ChoiceParameterDefinition.choices is just not analyzable.
-            return;
-        }
         props.put(name, new DescribableParameter(this, type, name, setter));
     }
 


### PR DESCRIPTION
[JENKINS-53917](https://issues.jenkins-ci.org/browse/JENKINS-53917)

Undoes #41. Can be caught by https://github.com/jenkinsci/workflow-multibranch-plugin/pull/81. Will file a downstream for `workflow-cps` to handle the original behavior.