### PR TITLE
[JENKINS-44892] DescribableModel customization

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/CustomDescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/CustomDescribableModel.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.structs.describable;
+
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Allows the usage of {@link DescribableModel} to be fine-tuned to cover special cases such as backwards compatibility.
+ * Normally introspection of a struct class with {@link DataBoundConstructor} and {@link DataBoundSetter} suffices for databinding.
+ * This facility allows the definer of the struct to accept variant inputs to {@link DescribableModel#instantiate(Map)},
+ * or recommend variant outputs for {@link DescribableModel#uninstantiate2(Object)}.
+ * This is somewhat analogous to implementing a {@code readResolve} method to customize XStream serialization behavior.
+ * @see CustomDescription
+ */
+@Restricted(Beta.class)
+public interface CustomDescribableModel<T> {
+
+    /**
+     * The class to which {@link CustomDescription} is applied.
+     */
+    Class<T> getType();
+
+    /**
+     * Permits customization of the behavior of {@link DescribableModel#instantiate(Map)}.
+     * @param standard offers the stock behavior for this object or some substructure
+     */
+    default T instantiate(Map<String, Object> arguments, StandardInstantiator standard) throws Exception {
+        return standard.instantiate(getType(), arguments);
+    }
+
+    /**
+     * Permits customization of the behavior of {@link DescribableModel#uninstantiate2(Object)}.
+     * @param standard offers the stock behavior for this object or some substructure
+     */
+    default UninstantiatedDescribable uninstantiate(T object, StandardUninstantiator standard) throws UnsupportedOperationException {
+        return standard.uninstantiate(object);
+    }
+
+    /**
+     * Marker for a struct class that should have a special model.
+     * Place on a {@link Describable}, <em>not</em> its {@link Descriptor}.
+     * TODO better to make an optional interface of Descriptor
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Documented
+    @interface CustomDescription {
+        Class<? extends CustomDescribableModel<?>> value();
+    }
+
+    // TODO the StandardInstantiator/StandardUninstantiator pattern may be overkill; perhaps better to just let the customization process a Map
+
+    /**
+     * Permits delegation to the stock behavior of {@link DescribableModel#instantiate(Map)}.
+     */
+    interface StandardInstantiator {
+        <T> T instantiate(Class<T> type, Map<String, Object> arguments) throws Exception;
+    }
+
+    /**
+     * Permits delegation to the stock behavior of {@link DescribableModel#uninstantiate2(Object)}.
+     */
+    interface StandardUninstantiator {
+        UninstantiatedDescribable uninstantiate(Object object) throws UnsupportedOperationException;
+    }
+
+}

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -307,10 +307,8 @@ public final class DescribableModel<T> implements Serializable {
         return Collections.unmodifiableMap(r);
     }
 
-    private static UninstantiatedDescribable deeplyImmutable(UninstantiatedDescribable ud1) {
-        UninstantiatedDescribable ud2 = new UninstantiatedDescribable(ud1.getSymbol(), ud1.getKlass(), deeplyImmutable(ud1.getArguments()));
-        ud2.setModel(ud1.getModel());
-        return ud2;
+    private static UninstantiatedDescribable deeplyImmutable(UninstantiatedDescribable ud) {
+        return ud.withArguments(deeplyImmutable(ud.getArguments()));
     }
 
         // adapted from RequestImpl

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -270,7 +270,9 @@ public final class DescribableModel<T> implements Serializable {
     public T instantiate(Map<String,?> arguments) throws Exception {
         CustomDescribableModel cdm = CustomDescribableModel.of(type);
         if (cdm != null) {
-            arguments = cdm.customInstantiate(deeplyImmutable(arguments));
+            Map<String, Object> input = deeplyImmutable(arguments);
+            arguments = cdm.customInstantiate(input);
+            LOGGER.log(Level.FINE, "{0} translated {1} to {2}", new Object[] {cdm.getClass(), input, arguments});
         }
         if (arguments.containsKey(ANONYMOUS_KEY)) {
             if (arguments.size()!=1)
@@ -669,7 +671,9 @@ public final class DescribableModel<T> implements Serializable {
         ud.setModel(this);
         CustomDescribableModel cdm = CustomDescribableModel.of(type);
         if (cdm != null) {
-            ud = cdm.customUninstantiate(deeplyImmutable(ud));
+            UninstantiatedDescribable input = deeplyImmutable(ud);
+            ud = cdm.customUninstantiate(input);
+            LOGGER.log(Level.FINE, "{0} translated {1} to {2}", new Object[] {cdm.getClass(), input, ud});
         }
         return ud;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -268,29 +268,9 @@ public final class DescribableModel<T> implements Serializable {
      * and only one subtype is registered (as a {@link Descriptor}) with that simple name.
      */
     public T instantiate(Map<String,?> arguments) throws Exception {
-        return instantiate(arguments, true);
-    }
-
-    // type capture
-    private static <T> T instantiate(CustomDescribableModel<T> model, Map<String, Object> arguments, CustomDescribableModel.StandardInstantiator standard) throws Exception {
-        return model.getType().cast(model.instantiate(arguments, standard));
-    }
-
-    @SuppressWarnings("Convert2Lambda") // javac gets too confused when the generic types are involved
-    private T instantiate(Map<String,?> arguments, boolean useCustomDescribableModel) throws Exception {
-        if (useCustomDescribableModel) {
-            CustomDescribableModel.CustomDescription customDescription = type.getAnnotation(CustomDescribableModel.CustomDescription.class);
-            if (customDescription != null) {
-                CustomDescribableModel<?> customModel = customDescription.value().newInstance();
-                if (customModel.getType() != type) {
-                    throw new IllegalStateException("misapplied annotation on " + type);
-                }
-                return type.cast(instantiate(customModel, new HashMap<>(arguments), new CustomDescribableModel.StandardInstantiator() {
-                    @Override public <T> T instantiate(Class<T> otherType, Map<String, Object> otherArguments) throws Exception {
-                        return new DescribableModel<>(otherType).instantiate(otherArguments, false);
-                    }
-                }));
-            }
+        CustomDescribableModel cdm = CustomDescribableModel.of(type);
+        if (cdm != null) {
+            arguments = cdm.customInstantiate(deeplyImmutable(arguments));
         }
         if (arguments.containsKey(ANONYMOUS_KEY)) {
             if (arguments.size()!=1)
@@ -310,6 +290,27 @@ public final class DescribableModel<T> implements Serializable {
         } catch (Exception x) {
             throw new IllegalArgumentException("Could not instantiate " + arguments + " for " + this + ": " + x, x);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> deeplyImmutable(Map<String, ?> m) {
+        Map<String, Object> r = new HashMap<>();
+        for (Map.Entry<String, ?> e : m.entrySet()) {
+            Object v = e.getValue();
+            if (v instanceof UninstantiatedDescribable) {
+                v = deeplyImmutable((UninstantiatedDescribable) v);
+            } else if (v instanceof Map) {
+                v = deeplyImmutable((Map) v);
+            }
+            r.put(e.getKey(), v);
+        }
+        return Collections.unmodifiableMap(r);
+    }
+
+    private static UninstantiatedDescribable deeplyImmutable(UninstantiatedDescribable ud1) {
+        UninstantiatedDescribable ud2 = new UninstantiatedDescribable(ud1.getSymbol(), ud1.getKlass(), deeplyImmutable(ud1.getArguments()));
+        ud2.setModel(ud1.getModel());
+        return ud2;
     }
 
         // adapted from RequestImpl
@@ -596,29 +597,6 @@ public final class DescribableModel<T> implements Serializable {
      * @throws UnsupportedOperationException if the class does not follow the expected structure
      */
     public UninstantiatedDescribable uninstantiate2(T o) throws UnsupportedOperationException {
-        return uninstantiate2(o, true);
-    }
-
-    private UninstantiatedDescribable uninstantiate2(T o, boolean useCustomDescribableModel) throws UnsupportedOperationException {
-        if (useCustomDescribableModel) {
-            CustomDescribableModel.CustomDescription customDescription = type.getAnnotation(CustomDescribableModel.CustomDescription.class);
-            if (customDescription != null) {
-                CustomDescribableModel customModel;
-                try {
-                    customModel = customDescription.value().newInstance();
-                } catch (Exception x) {
-                    throw new UnsupportedOperationException(x); // should have been declared to throw Exception
-                }
-                if (customModel.getType() != type) {
-                    throw new IllegalStateException("misapplied annotation on " + type);
-                }
-                return customModel.uninstantiate(o, new CustomDescribableModel.StandardUninstantiator() {
-                    @Override public UninstantiatedDescribable uninstantiate(Object object) throws UnsupportedOperationException {
-                        return new DescribableModel(object.getClass()).uninstantiate2(object, false);
-                    }
-                });
-            }
-        }
         if (o==null)
             throw new IllegalArgumentException("Expected "+type+" but got null");
         if (!type.isInstance(o))
@@ -691,6 +669,10 @@ public final class DescribableModel<T> implements Serializable {
         }
         UninstantiatedDescribable ud = new UninstantiatedDescribable(symbolOf(o), null, r);
         ud.setModel(this);
+        CustomDescribableModel cdm = CustomDescribableModel.of(type);
+        if (cdm != null) {
+            ud = cdm.customUninstantiate(deeplyImmutable(ud));
+        }
         return ud;
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -35,6 +35,17 @@ public class UninstantiatedDescribable implements Serializable {
     }
 
     /**
+     * Makes a copy of this struct with an alternate argument map.
+     * @param arguments a replacement for {@link #getArguments}
+     * @return a new object with the same {@link #getSymbol}, {@link #getKlass}, and {@link #getModel}
+     */
+    public UninstantiatedDescribable withArguments(Map<String, ?> arguments) {
+        UninstantiatedDescribable copy = new UninstantiatedDescribable(symbol, klass, arguments);
+        copy.model = model;
+        return copy;
+    }
+
+    /**
      * If this nested describable has a suitable {@linkplain Symbol symbol name},
      * this method returns one.
      *


### PR DESCRIPTION
[JENKINS-44892](https://issues.jenkins-ci.org/browse/JENKINS-44892): API permitting plugins which define structs to fine-tune how their surface form is presented, particularly in Pipeline Groovy.