### PR TITLE
[WIP] Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.21</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Work in progress to make sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))
