### PR TITLE
[JENKINS-33217] validate instantiate arg map

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -293,7 +293,7 @@ public final class DescribableModel<T> implements Serializable {
         }
         if (erroneous.size() > 0) {
             throw new IllegalArgumentException("Unknown parameter(s) found for class type '" +
-                    this.type.getSimpleName() + "': " +
+                    this.type.getName() + "': " +
                     String.join(",", erroneous));
         }
 
@@ -303,7 +303,7 @@ public final class DescribableModel<T> implements Serializable {
             injectSetters(o, arguments);
             return o;
         } catch (Exception x) {
-            throw new IllegalArgumentException("Could not instantiate " + arguments + " for " + this + ": " + x, x);
+            throw new IllegalArgumentException("Could not instantiate " + arguments + " for " + this.type.getName() + ": " + x, x);
         }
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -87,7 +87,7 @@ import static org.jenkinsci.plugins.structs.describable.UninstantiatedDescribabl
  */
 @SuppressFBWarnings("SE_BAD_FIELD") // defines writeReplace
 public final class DescribableModel<T> implements Serializable {
-    public static boolean STRICT_PARAMETER_CHECKING = true;
+    public static boolean STRICT_PARAMETER_CHECKING = !Main.isUnitTest;
     /**
      * Type that this model represents.
      */
@@ -310,14 +310,14 @@ public final class DescribableModel<T> implements Serializable {
             arguments = Collections.singletonMap(rp.getName(),arguments.get(ANONYMOUS_KEY));
         }
 
-        if (STRICT_PARAMETER_CHECKING) {
-            Set<String> erroneous =  new TreeSet<>(arguments.keySet());
-            erroneous.removeAll(parameters.keySet());
-            if (erroneous.size() > 0) {
-                String msg = "WARNING: Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
-                if (Main.isUnitTest) {
-                    throw new IllegalArgumentException(msg);
-                } else {
+        Set<String> erroneous =  new TreeSet<>(arguments.keySet());
+        erroneous.removeAll(parameters.keySet());
+        if (erroneous.size() > 0) {
+            String msg = "WARNING: Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
+            if (Main.isUnitTest) {
+                throw new IllegalArgumentException(msg);
+            } else {
+                if (STRICT_PARAMETER_CHECKING) {
                     listener.getLogger().println(msg);
                 }
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -313,7 +313,7 @@ public final class DescribableModel<T> implements Serializable {
             if (Main.isUnitTest) {
                 throw new IllegalArgumentException(msg);
             } else {
-                listener.getLogger().println(msg);
+                listener.getLogger().format("WARNING: %s", msg);
             }
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -87,6 +87,7 @@ import static org.jenkinsci.plugins.structs.describable.UninstantiatedDescribabl
  */
 @SuppressFBWarnings("SE_BAD_FIELD") // defines writeReplace
 public final class DescribableModel<T> implements Serializable {
+    public static boolean STRICT_PARAMETER_CHECKING = true;
     /**
      * Type that this model represents.
      */
@@ -309,14 +310,16 @@ public final class DescribableModel<T> implements Serializable {
             arguments = Collections.singletonMap(rp.getName(),arguments.get(ANONYMOUS_KEY));
         }
 
-        Set<String> erroneous =  new TreeSet<>(arguments.keySet());
-        erroneous.removeAll(parameters.keySet());
-        if (erroneous.size() > 0) {
-            String msg = "WARNING: Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
-            if (Main.isUnitTest) {
-                throw new IllegalArgumentException(msg);
-            } else {
-                listener.getLogger().println(msg);
+        if (STRICT_PARAMETER_CHECKING) {
+            Set<String> erroneous =  new TreeSet<>(arguments.keySet());
+            erroneous.removeAll(parameters.keySet());
+            if (erroneous.size() > 0) {
+                String msg = "WARNING: Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
+                if (Main.isUnitTest) {
+                    throw new IllegalArgumentException(msg);
+                } else {
+                    listener.getLogger().println(msg);
+                }
             }
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -280,7 +280,7 @@ public final class DescribableModel<T> implements Serializable {
         if (cdm != null) {
             Map<String, Object> input = deeplyImmutable(arguments);
             arguments = cdm.customInstantiate(input);
-            listener.getLogger().format("{0} translated {1} to {2}", new Object[] {cdm.getClass(), input, arguments});
+            listener.getLogger().format("%s translated %s to %s", cdm.getClass(), input, arguments);
         }
         if (arguments.containsKey(ANONYMOUS_KEY)) {
             if (arguments.size()!=1)

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -4,6 +4,7 @@ import com.google.common.primitives.Primitives;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.GString;
 import hudson.ExtensionList;
+import hudson.Main;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.ParameterDefinition;
@@ -36,7 +37,18 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -277,9 +289,12 @@ public final class DescribableModel<T> implements Serializable {
         Set<String> erroneous =  new TreeSet<>(arguments.keySet());
         erroneous.removeAll(parameters.keySet());
         if (erroneous.size() > 0) {
-            LOGGER.log(Level.WARNING, "Unknown parameter(s) found for class type '" +
-                    this.type.getName() + "': " +
-                    String.join(",", erroneous));
+            String msg = "Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
+            if (Main.isUnitTest) {
+                throw new IllegalArgumentException(msg);
+            } else {
+                LOGGER.log(Level.WARNING, msg);
+            }
         }
 
         try {

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -284,6 +284,18 @@ public final class DescribableModel<T> implements Serializable {
             arguments = Collections.singletonMap(rp.getName(),arguments.get(ANONYMOUS_KEY));
         }
 
+        // Check for erroneous arguments
+        List<String> erroneous = new ArrayList<>();
+        for (String arg : arguments.keySet()) {
+            if (!parameters.containsKey(arg)) {
+                erroneous.add(arg);
+            }
+        }
+        if (erroneous.size() > 0) {
+            throw new IllegalArgumentException("The following arguments were not recognized: "+
+                    String.join(",", erroneous));
+        }
+
         try {
             Object[] args = buildArguments(arguments, constructor.getGenericParameterTypes(), constructorParamNames, true);
             T o = constructor.newInstance(args);

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -259,6 +259,9 @@ public final class DescribableModel<T> implements Serializable {
         return type.getSimpleName();
     }
 
+    /**
+     * @deprecated instead use {@link #instantiate(Map, TaskListener)}
+     */
     @Deprecated
     public T instantiate(Map<String,?> arguments) throws IllegalArgumentException {
         return instantiate(arguments, new LogTaskListener(LOGGER, Level.FINE));
@@ -266,14 +269,6 @@ public final class DescribableModel<T> implements Serializable {
 
     /**
      * Creates an instance of a class via {@link DataBoundConstructor} and {@link DataBoundSetter}.
-     * @param arguments
-     *      The arguments used to create the instance
-     * @param listener
-     *      Listener to record any instantiation warnings
-     * @return
-     *      The instantiated object
-     * @throws IllegalArgumentException
-     *
      * <p>
      * The arguments may be primitives (as wrappers) or {@link String}s if that is their declared type.
      * {@link Character}s, {@link Enum}s, and {@link URL}s may be represented by {@link String}s.
@@ -284,8 +279,16 @@ public final class DescribableModel<T> implements Serializable {
      * or it may be omitted if the argument is declared to take a concrete type;
      * or {@link Class#getSimpleName} may be used in case the argument type is {@link Describable}
      * and only one subtype is registered (as a {@link Descriptor}) with that simple name.
+     *
+     * @param arguments
+     *      The arguments used to create the instance
+     * @param listener
+     *      Listener to record any instantiation warnings
+     * @return
+     *      The instantiated object
+     * @throws IllegalArgumentException
      */
-    public T instantiate(Map<String,?> arguments, TaskListener listener) throws IllegalArgumentException {
+    public T instantiate(Map<String,?> arguments, @CheckForNull TaskListener listener) throws IllegalArgumentException {
         if (listener == null) {
             listener = new LogTaskListener(LOGGER, Level.WARNING);
         }
@@ -309,11 +312,11 @@ public final class DescribableModel<T> implements Serializable {
         Set<String> erroneous =  new TreeSet<>(arguments.keySet());
         erroneous.removeAll(parameters.keySet());
         if (erroneous.size() > 0) {
-            String msg = "Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
+            String msg = "WARNING: Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
             if (Main.isUnitTest) {
                 throw new IllegalArgumentException(msg);
             } else {
-                listener.getLogger().format("WARNING: %s", msg);
+                listener.getLogger().println(msg);
             }
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -21,6 +21,8 @@ import org.codehaus.groovy.reflection.ReflectionCache;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jvnet.tiger_types.Types;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.ClassDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -88,7 +90,8 @@ import static org.jenkinsci.plugins.structs.describable.UninstantiatedDescribabl
 @SuppressFBWarnings("SE_BAD_FIELD") // defines writeReplace
 public final class DescribableModel<T> implements Serializable {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control warnings that instantiate parameters will be ignored
-    public static boolean STRICT_PARAMETER_CHECKING = !Main.isUnitTest;
+    @Restricted(NoExternalUse.class)
+    public static boolean STRICT_PARAMETER_CHECKING = Main.isUnitTest;
     /**
      * Type that this model represents.
      */
@@ -315,12 +318,10 @@ public final class DescribableModel<T> implements Serializable {
         erroneous.removeAll(parameters.keySet());
         if (erroneous.size() > 0) {
             String msg = "WARNING: Unknown parameter(s) found for class type '" + this.type.getName() + "': " + String.join(",", erroneous);
-            if (Main.isUnitTest) {
+            if (STRICT_PARAMETER_CHECKING) {
                 throw new IllegalArgumentException(msg);
             } else {
-                if (STRICT_PARAMETER_CHECKING) {
-                    listener.getLogger().println(msg);
-                }
+                listener.getLogger().println(msg);
             }
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -276,6 +276,10 @@ public final class DescribableModel<T> implements Serializable {
     }
 
     public T instantiate(Map<String,?> arguments, TaskListener listener) throws IllegalArgumentException {
+        if (listener == null) {
+            listener = new LogTaskListener(LOGGER, Level.FINE);
+        }
+
         CustomDescribableModel cdm = CustomDescribableModel.of(type);
         if (cdm != null) {
             Map<String, Object> input = deeplyImmutable(arguments);
@@ -441,7 +445,7 @@ public final class DescribableModel<T> implements Serializable {
         } else if (o==null) {
             return null;
         } else if (o instanceof UninstantiatedDescribable) {
-            return ((UninstantiatedDescribable)o).instantiate(erased);
+            return ((UninstantiatedDescribable)o).instantiate(erased, listener);
         } else if (o instanceof Map) {
             Map<String,Object> m = new HashMap<String,Object>();
             for (Map.Entry<?,?> entry : ((Map<?,?>) o).entrySet()) {
@@ -647,7 +651,7 @@ public final class DescribableModel<T> implements Serializable {
 
         Object control = null;
         try {
-            control = instantiate(constructorOnlyDataBoundProps);
+            control = instantiate(constructorOnlyDataBoundProps, null);
         } catch (Exception x) {
             LOGGER.log(Level.WARNING, "Cannot create control version of " + type + " using " + constructorOnlyDataBoundProps, x);
         }
@@ -671,7 +675,7 @@ public final class DescribableModel<T> implements Serializable {
             // we have some deprecated properties
             control = null;
             try {
-                control = instantiate(nonDeprecatedDataBoundProps);
+                control = instantiate(nonDeprecatedDataBoundProps, null);
             } catch (Exception x) {
                 LOGGER.log(Level.WARNING,
                         "Cannot create control version of " + type + " using " + nonDeprecatedDataBoundProps, x);

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -36,17 +36,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -284,15 +274,10 @@ public final class DescribableModel<T> implements Serializable {
             arguments = Collections.singletonMap(rp.getName(),arguments.get(ANONYMOUS_KEY));
         }
 
-        // Check for erroneous arguments
-        List<String> erroneous = new ArrayList<>();
-        for (String arg : arguments.keySet()) {
-            if (!parameters.containsKey(arg)) {
-                erroneous.add(arg);
-            }
-        }
+        Set<String> erroneous =  new TreeSet<>(arguments.keySet());
+        erroneous.removeAll(parameters.keySet());
         if (erroneous.size() > 0) {
-            throw new IllegalArgumentException("Unknown parameter(s) found for class type '" +
+            LOGGER.log(Level.WARNING, "Unknown parameter(s) found for class type '" +
                     this.type.getName() + "': " +
                     String.join(",", erroneous));
         }

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -292,7 +292,8 @@ public final class DescribableModel<T> implements Serializable {
             }
         }
         if (erroneous.size() > 0) {
-            throw new IllegalArgumentException("Unknown parameter(s): "+
+            throw new IllegalArgumentException("Unknown parameter(s) found for class type '" +
+                    this.type.getSimpleName() + "': " +
                     String.join(",", erroneous));
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -87,6 +87,7 @@ import static org.jenkinsci.plugins.structs.describable.UninstantiatedDescribabl
  */
 @SuppressFBWarnings("SE_BAD_FIELD") // defines writeReplace
 public final class DescribableModel<T> implements Serializable {
+    @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control warnings that instantiate parameters will be ignored
     public static boolean STRICT_PARAMETER_CHECKING = !Main.isUnitTest;
     /**
      * Type that this model represents.

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -292,7 +292,7 @@ public final class DescribableModel<T> implements Serializable {
             }
         }
         if (erroneous.size() > 0) {
-            throw new IllegalArgumentException("The following arguments were not recognized: "+
+            throw new IllegalArgumentException("Unknown parameter(s): "+
                     String.join(",", erroneous));
         }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -158,6 +158,9 @@ public class UninstantiatedDescribable implements Serializable {
         }
     }
 
+    /**
+     * @deprecated instead use {@link #instantiate(TaskListener)}
+     */
     @Deprecated
     public Object instantiate() throws Exception {
         DescribableModel m = getModel();
@@ -181,16 +184,25 @@ public class UninstantiatedDescribable implements Serializable {
     }
 
     /**
+     * @deprecated instead use {@link #instantiate(Class, TaskListener)}
+     */
+    @Deprecated
+    public <T> T instantiate(Class<T> base) throws Exception {
+        return instantiate(base, null);
+    }
+
+    /**
      * Instantiates an actual {@link Describable} object from the specified arguments.
      *
      * @param base
      *      The expected type of the instance. The interpretation of the symbol and $class
      *      depends on this parameter.
+     * @param listener
+     *      Listener to record any instantiation warnings
+     * @return
+     *      The instantiated object
+     * @throws Exception
      */
-    public <T> T instantiate(Class<T> base) throws Exception {
-        return instantiate(base, null);
-    }
-
     public <T> T instantiate(Class<T> base, TaskListener listener) throws Exception {
         Class<?> c = DescribableModel.resolveClass(base, klass, symbol);
         return base.cast(new DescribableModel(c).instantiate(arguments, listener));

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -158,16 +158,23 @@ public class UninstantiatedDescribable implements Serializable {
         }
     }
 
-    /**
-     * Instantiates an actual {@link Describable} through {@linkplain #getModel() the model},
-     * unless {@link #klass} or {@link #symbol} will be set to specify a specific type, in which
-     * case that takes a precedence.
-     */
+    @Deprecated
     public Object instantiate() throws Exception {
         DescribableModel m = getModel();
         return instantiate(m!=null ? m.getType() : Object.class, null);
     }
 
+    /**
+     * Instantiates an actual {@link Describable} through {@linkplain #getModel() the model},
+     * unless {@link #klass} or {@link #symbol} will be set to specify a specific type, in which
+     * case that takes a precedence.
+     *
+     * @param listener
+     *      Listener to record any instantiation warnings
+     * @return
+     *      The instantiated object
+     * @throws Exception
+     */
     public Object instantiate(TaskListener listener) throws Exception {
         DescribableModel m = getModel();
         return instantiate(m!=null ? m.getType() : Object.class, listener);

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.structs.describable;
 
 import hudson.model.Describable;
+import hudson.model.TaskListener;
 import org.jenkinsci.Symbol;
 
 import javax.annotation.Nullable;
@@ -164,7 +165,12 @@ public class UninstantiatedDescribable implements Serializable {
      */
     public Object instantiate() throws Exception {
         DescribableModel m = getModel();
-        return instantiate(m!=null ? m.getType() : Object.class);
+        return instantiate(m!=null ? m.getType() : Object.class, null);
+    }
+
+    public Object instantiate(TaskListener listener) throws Exception {
+        DescribableModel m = getModel();
+        return instantiate(m!=null ? m.getType() : Object.class, listener);
     }
 
     /**
@@ -175,8 +181,12 @@ public class UninstantiatedDescribable implements Serializable {
      *      depends on this parameter.
      */
     public <T> T instantiate(Class<T> base) throws Exception {
+        return instantiate(base, null);
+    }
+
+    public <T> T instantiate(Class<T> base, TaskListener listener) throws Exception {
         Class<?> c = DescribableModel.resolveClass(base, klass, symbol);
-        return base.cast(new DescribableModel(c).instantiate(arguments));
+        return base.cast(new DescribableModel(c).instantiate(arguments, listener));
     }
 
     public static UninstantiatedDescribable from(Object o) {

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -93,7 +93,7 @@ public class DescribableModelTest {
             Assert.fail("Instantiation should have failed due to unnecessary arguments");
         } catch (Exception e) {
             assertThat(e, Matchers.instanceOf(IllegalArgumentException.class));
-            assertThat(e.getMessage(), is("Unknown parameter(s) found for class type '" +
+            assertThat(e.getMessage(), is("WARNING: Unknown parameter(s) found for class type '" +
                 C.class.getName() + "': garbage,junk"));
         }
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -91,7 +91,7 @@ public class DescribableModelTest {
     @Test
     public void erroneousParameters() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(is("Unknown parameter(s): garbage,junk"));
+        exceptionRule.expectMessage(is("Unknown parameter(s) found for class type 'C': garbage,junk"));
         Map<String,Object> args = map("text", "hello", "flag", true, "garbage", "!", "junk", "splat");
         instantiate(C.class,  args);
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -91,7 +91,8 @@ public class DescribableModelTest {
     @Test
     public void erroneousParameters() throws Exception {
         exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(is("Unknown parameter(s) found for class type 'C': garbage,junk"));
+        exceptionRule.expectMessage(is("Unknown parameter(s) found for class type '" +
+                C.class.getName() + "': garbage,junk"));
         Map<String,Object> args = map("text", "hello", "flag", true, "garbage", "!", "junk", "splat");
         instantiate(C.class,  args);
     }


### PR DESCRIPTION
Add a check for any erroneous parameters when calling instantiate. Previously, instantiate would ignore any stray parameters.

See [JENKINS-33217](https://issues.jenkins-ci.org/browse/JENKINS-33217)

@abayer 
@dwnusbaum 
@jglick 