### PR TITLE
refactorings and general code cleanup

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
@@ -33,9 +33,9 @@ import java.util.logging.Logger;
  */
 @Extension
 public class SymbolLookup {
-    private final ConcurrentMap<Key,Object> cache = new ConcurrentHashMap<Key, Object>();
+    private final ConcurrentMap<Key,Object> cache = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Key,Object> noHitCache = new ConcurrentHashMap<Key, Object>();
+    private final ConcurrentMap<Key,Object> noHitCache = new ConcurrentHashMap<>();
 
     static final Object NO_HIT = new Object();
 
@@ -48,7 +48,7 @@ public class SymbolLookup {
     Set<String> pluginNames = Collections.EMPTY_SET;
 
     private static HashSet<String> pluginsToNames(List<PluginWrapper> plugins) {
-        HashSet<String> pluginNames = new HashSet<String>(plugins.size());
+        HashSet<String> pluginNames = new HashSet<>(plugins.size());
         for (PluginWrapper pw : plugins) {
             pluginNames.add(pw.getShortName());
         }
@@ -198,7 +198,7 @@ public class SymbolLookup {
      * Gets the singleton instance.
      */
     public static SymbolLookup get() {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.getInstanceOrNull();
         if (j == null) {
             throw new IllegalStateException();
         }
@@ -231,7 +231,7 @@ public class SymbolLookup {
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
             justification = "Jenkins.getInstance() can return null in theory.")
     @Nonnull public static Set<String> getSymbolValue(@Nonnull Class<?> c) {
-        Set<String> symbolValues = new LinkedHashSet<String>();
+        Set<String> symbolValues = new LinkedHashSet<>();
         Jenkins j = Jenkins.getInstanceOrNull();
         if (Describable.class.isAssignableFrom(c) && !Descriptor.class.isAssignableFrom(c) && j != null) {
             Descriptor<?> d = j.getDescriptor(c.asSubclass(Describable.class));

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -41,6 +41,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -97,7 +98,7 @@ public final class DescribableModel<T> implements Serializable {
      */
     private final Class<T> type;
 
-    private Map<String,DescribableParameter> parameters = new LinkedHashMap<String, DescribableParameter>(4);
+    private Map<String,DescribableParameter> parameters = new LinkedHashMap<>(4);
 
     /**
      * Read only view to {@link #parameters}
@@ -120,13 +121,13 @@ public final class DescribableModel<T> implements Serializable {
         if (mod != null && mod.type == clazz) {
             return mod;
         }
-        mod = new DescribableModel<T>(clazz);
+        mod = new DescribableModel<>(clazz);
         modelCache.put(clazz.getName(), mod);
         return mod;
     }
 
     /** Map class name to cached model. */
-    static ConcurrentHashMap<String, DescribableModel> modelCache = new ConcurrentHashMap<String, DescribableModel>();
+    static ConcurrentHashMap<String, DescribableModel> modelCache = new ConcurrentHashMap<>();
 
     /**
      * Loads a definition of the structure of a class: what kind of data
@@ -161,7 +162,7 @@ public final class DescribableModel<T> implements Serializable {
         }
 
         // rest of the properties will be sorted alphabetically
-        Map<String,DescribableParameter> rest = new TreeMap<String, DescribableParameter>();
+        Map<String,DescribableParameter> rest = new TreeMap<>();
 
         for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
             for (Field f : c.getDeclaredFields()) {
@@ -465,7 +466,7 @@ public final class DescribableModel<T> implements Serializable {
         } else if (o instanceof UninstantiatedDescribable) {
             return ((UninstantiatedDescribable)o).instantiate(erased, listener);
         } else if (o instanceof Map) {
-            Map<String,Object> m = new HashMap<String,Object>();
+            Map<String,Object> m = new HashMap<>();
             for (Map.Entry<?,?> entry : ((Map<?,?>) o).entrySet()) {
                 m.put((String) entry.getKey(), entry.getValue());
             }
@@ -580,7 +581,7 @@ public final class DescribableModel<T> implements Serializable {
      * Apply {@link #coerce(String, Type, Object, TaskListener)} method to a collection item.
      */
     private List<Object> coerceList(String context, Type type, List<?> list, TaskListener listener) throws Exception {
-        List<Object> r = new ArrayList<Object>();
+        List<Object> r = new ArrayList<>();
         for (Object elt : list) {
             r.add(coerce(context, type, elt, listener));
         }
@@ -604,7 +605,7 @@ public final class DescribableModel<T> implements Serializable {
     }
 
     static Set<Class<?>> findSubtypes(Class<?> supertype) {
-        Set<Class<?>> clazzes = new HashSet<Class<?>>();
+        Set<Class<?>> clazzes = new HashSet<>();
         // Jenkins.getDescriptorList does not work well since it is limited to descriptors declaring one supertype, and does not work at all for SimpleBuildStep.
         for (Descriptor<?> d : ExtensionList.lookup(Descriptor.class)) {
             if (supertype.isAssignableFrom(d.clazz)) {
@@ -648,9 +649,9 @@ public final class DescribableModel<T> implements Serializable {
         if (!type.isInstance(o))
             throw new IllegalArgumentException("Expected "+type+" but got an instance of "+o.getClass());
 
-        Map<String, Object> r = new TreeMap<String, Object>();
-        Map<String, Object> constructorOnlyDataBoundProps = new TreeMap<String, Object>();
-        Map<String, Object> nonDeprecatedDataBoundProps = new TreeMap<String, Object>();
+        Map<String, Object> r = new TreeMap<>();
+        Map<String, Object> constructorOnlyDataBoundProps = new TreeMap<>();
+        Map<String, Object> nonDeprecatedDataBoundProps = new TreeMap<>();
         for (DescribableParameter p : parameters.values()) {
             Object v = p.inspect(o);
             if (p.isRequired() && v==null) {
@@ -776,7 +777,7 @@ public final class DescribableModel<T> implements Serializable {
         for (Klass<?> c = Klass.java(type); c != null; c = c.getSuperClass()) {
             URL u = c.getResource(name);
             if (u != null) {
-                return IOUtils.toString(u, "UTF-8");
+                return IOUtils.toString(u, StandardCharsets.UTF_8);
             }
         }
         return null;
@@ -808,7 +809,7 @@ public final class DescribableModel<T> implements Serializable {
 
     @Override public String toString() {
         StringBuilder b = new StringBuilder();
-        toString(b, new Stack<Class<?>>());
+        toString(b, new Stack<>());
         return b.toString();
     }
 
@@ -848,7 +849,7 @@ public final class DescribableModel<T> implements Serializable {
         return defaultPrimitiveValue.get(type);
     }
 
-    private static final Map<Class,Object> defaultPrimitiveValue = new HashMap<Class, Object>();
+    private static final Map<Class,Object> defaultPrimitiveValue = new HashMap<>();
     static {
         defaultPrimitiveValue.put(boolean.class, false);
         defaultPrimitiveValue.put(byte.class, (byte) 0);

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableParameter.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableParameter.java
@@ -131,7 +131,7 @@ public final class DescribableParameter {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        toString(b, new Stack<Class<?>>());
+        toString(b, new Stack<>());
         return b.toString();
     }
 
@@ -179,13 +179,13 @@ public final class DescribableParameter {
             return o.toString();
         } else if (o instanceof Object[]) {
             Object[] array = (Object[]) o;
-            List<Object> list = new ArrayList<Object>(array.length);
+            List<Object> list = new ArrayList<>(array.length);
             for (Object elt : array) {
                 list.add(uncoerce(elt, array.getClass().getComponentType()));
             }
             return list;
         } else if (o instanceof Collection && Types.isSubClassOf(type, Collection.class)) {
-            List<Object> list = new ArrayList<Object>(((Collection) o).size());
+            List<Object> list = new ArrayList<>(((Collection) o).size());
             for (Object elt : (Collection<?>) o) {
                 list.add(uncoerce(elt, Types.getTypeArgument(Types.getBaseClass(type,Collection.class),0,Object.class)));
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
@@ -46,7 +46,7 @@ public abstract class ParameterType {
                     return new AtomicType(c);
                 }
                 if (Enum.class.isAssignableFrom(c)) {
-                    List<String> constants = new ArrayList<String>();
+                    List<String> constants = new ArrayList<>();
                     for (Enum<?> value : c.asSubclass(Enum.class).getEnumConstants()) {
                         constants.add(value.name());
                     }
@@ -68,16 +68,13 @@ public abstract class ParameterType {
                     return new HomogeneousObjectType(c);
                 } else {
                     // Definitely heterogeneous.
-                    Map<String,List<Class<?>>> subtypesBySimpleName = new HashMap<String,List<Class<?>>>();
+                    Map<String,List<Class<?>>> subtypesBySimpleName = new HashMap<>();
                     for (Class<?> subtype : subtypes) {
                         String simpleName = subtype.getSimpleName();
-                        List<Class<?>> bySimpleName = subtypesBySimpleName.get(simpleName);
-                        if (bySimpleName == null) {
-                            subtypesBySimpleName.put(simpleName, bySimpleName = new ArrayList<Class<?>>());
-                        }
+                        List<Class<?>> bySimpleName = subtypesBySimpleName.computeIfAbsent(simpleName, k -> new ArrayList<>());
                         bySimpleName.add(subtype);
                     }
-                    Map<String,DescribableModel<?>> types = new TreeMap<String,DescribableModel<?>>();
+                    Map<String,DescribableModel<?>> types = new TreeMap<>();
                     for (Map.Entry<String,List<Class<?>>> entry : subtypesBySimpleName.entrySet()) {
                         if (entry.getValue().size() == 1) { // normal case: unambiguous via simple name
                             try {
@@ -112,7 +109,7 @@ public abstract class ParameterType {
     @Override
     public final String toString() {
         StringBuilder b = new StringBuilder();
-        toString(b, new Stack<Class<?>>());
+        toString(b, new Stack<>());
         return b.toString();
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java
@@ -7,10 +7,10 @@ import org.jenkinsci.Symbol;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.TreeMap;
 import javax.annotation.CheckForNull;
 
@@ -139,7 +139,7 @@ public class UninstantiatedDescribable implements Serializable {
      * Converts this {@link UninstantiatedDescribable} to a literal map expression without recursively doing so for children.
      */
     public Map<String,Object> toShallowMap() {
-        Map<String,Object> r = new TreeMap<String, Object>(arguments);
+        Map<String,Object> r = new TreeMap<>(arguments);
         if (klass !=null)
             r.put(DescribableModel.CLAZZ, klass);
 // there's no use writing both $class and $symbol. $symbol is little more readable, but given that this is already
@@ -221,8 +221,8 @@ public class UninstantiatedDescribable implements Serializable {
 
         UninstantiatedDescribable that = (UninstantiatedDescribable) o;
 
-        if (symbol != null ? !symbol.equals(that.symbol) : that.symbol != null) return false;
-        if (klass != null ? !klass.equals(that.klass) : that.klass != null) return false;
+        if (!Objects.equals(symbol, that.symbol)) return false;
+        if (!Objects.equals(klass, that.klass)) return false;
         return arguments.equals(that.arguments);
 
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/FishingNet.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/FishingNet.java
@@ -6,6 +6,8 @@ import hudson.model.Descriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 /**
  * "net" symbols are on two descriptors.
  *
@@ -20,6 +22,7 @@ public class FishingNet extends AbstractDescribableImpl<FishingNet> implements F
     @Extension @Symbol("net")
     public static class DescriptorImpl extends Descriptor<FishingNet> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "fishing net";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/FishingRod.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/FishingRod.java
@@ -6,6 +6,8 @@ import hudson.model.Descriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 /**
  * "rod" symbol
  *
@@ -20,6 +22,7 @@ public class FishingRod extends AbstractDescribableImpl<FishingRod> implements F
     @Extension @Symbol("rod")
     public static class DescriptorImpl extends Descriptor<FishingRod> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "fishing rod";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/Internet.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/Internet.java
@@ -6,6 +6,8 @@ import hudson.model.Descriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 /**
  * "net" symbols are on two descriptors.
  *
@@ -19,6 +21,7 @@ public class Internet extends AbstractDescribableImpl<Internet> implements Tech 
     @Extension @Symbol("net")
     public static class DescriptorImpl extends Descriptor<Internet> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "internet";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupAnticacheTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupAnticacheTest.java
@@ -6,10 +6,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.Url;
 
 import java.io.File;
-import java.net.URI;
 
 /**
  * @author Sam Van Oort

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
@@ -53,8 +53,8 @@ public class SymbolLookupTest {
     @Test
     public void test() {
         assertNull(lookup.find(Object.class, "zoo"));
-        assertThat((Foo) lookup.find(Object.class, "foo"), is(sameInstance(this.foo)));
-        assertThat((Bar) lookup.find(Object.class, "bar"), is(sameInstance(this.bar)));
+        assertThat(lookup.find(Object.class, "foo"), is(sameInstance(this.foo)));
+        assertThat(lookup.find(Object.class, "bar"), is(sameInstance(this.bar)));
 
         // even if the symbol matches, if the type isn't valid the return value will be null
         assertNull(lookup.find(String.class, "foo"));
@@ -109,7 +109,7 @@ public class SymbolLookupTest {
     public static class SomeConfiguration extends GlobalConfiguration {}
 
     @Issue("JENKINS-57218")
-    @Test public void descriptorSansExtension() throws Exception {
+    @Test public void descriptorSansExtension() {
         SymbolLookup sl = rule.jenkins.getExtensionList(SymbolLookup.class).get(0);
         errors.checkThat("A is registered", sl.findDescriptor(Stuff.class, "a"), is(instanceOf(StuffA.DescriptorImpl.class)));
         errors.checkThat("B is not", sl.findDescriptor(Stuff.class, "b"), nullValue());

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AmbiguousArrayContainer.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AmbiguousArrayContainer.java
@@ -30,6 +30,8 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 public class AmbiguousArrayContainer extends AbstractDescribableImpl<AmbiguousArrayContainer> {
     private final Describable<?>[] array;
 
@@ -45,6 +47,7 @@ public class AmbiguousArrayContainer extends AbstractDescribableImpl<AmbiguousAr
     @Extension
     public static class DescriptorImpl extends Descriptor<AmbiguousArrayContainer> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "ambiguous array container";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AmbiguousContainer.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AmbiguousContainer.java
@@ -30,6 +30,8 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 public class AmbiguousContainer extends AbstractDescribableImpl<AmbiguousContainer> {
     public final Describable<?> ambiguous;
     public final Describable<?> unambiguous;
@@ -43,6 +45,7 @@ public class AmbiguousContainer extends AbstractDescribableImpl<AmbiguousContain
     @Extension
     public static class DescriptorImpl extends Descriptor<AmbiguousContainer> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "ambiguous container";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AmbiguousListContainer.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/AmbiguousListContainer.java
@@ -30,19 +30,23 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 public class AmbiguousListContainer extends AbstractDescribableImpl<AmbiguousListContainer> {
     public final List<Describable<?>> list;
 
     @DataBoundConstructor
     public AmbiguousListContainer(List<Describable<?>> list) {
-        this.list = new ArrayList<Describable<?>>(list);
+        this.list = new ArrayList<>(list);
     }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<AmbiguousListContainer> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "ambiguous list container";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/FirstAmbiguous.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/FirstAmbiguous.java
@@ -29,6 +29,8 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 public class FirstAmbiguous {
     public static class CommonName extends AbstractDescribableImpl<CommonName> {
         public final String one;
@@ -41,6 +43,7 @@ public class FirstAmbiguous {
         @Extension
         public static class DescriptorImpl extends Descriptor<CommonName> {
             @Override
+            @Nonnull
             public String getDisplayName() {
                 return "FirstAmbiguous$CommonName";
             }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/IntAndBool.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/IntAndBool.java
@@ -31,6 +31,8 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.Nonnull;
+
 /**
  * Testing coercion of strings to numbers and booleans
  *
@@ -55,6 +57,7 @@ public class IntAndBool extends AbstractDescribableImpl<IntAndBool> {
     @Symbol("intAndBool")
     public static class DescriptorImpl extends Descriptor<IntAndBool> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "An integer and a boolean";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/LoneStar.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/LoneStar.java
@@ -7,6 +7,8 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.Nonnull;
+
 /**
  * To test a single argument Describable
  *
@@ -31,6 +33,7 @@ public class LoneStar extends AbstractDescribableImpl<LoneStar> {
     @Symbol("texas")
     public static class DescriptorImpl extends Descriptor<LoneStar> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "Lone star state";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/SecondAmbiguous.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/SecondAmbiguous.java
@@ -29,6 +29,8 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 public class SecondAmbiguous {
     public static class CommonName extends AbstractDescribableImpl<CommonName> {
         public final String two;
@@ -41,6 +43,7 @@ public class SecondAmbiguous {
         @Extension
         public static class DescriptorImpl extends Descriptor<CommonName> {
             @Override
+            @Nonnull
             public String getDisplayName() {
                 return "SecondAmbiguous$CommonName";
             }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/ThreeStars.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/ThreeStars.java
@@ -6,6 +6,8 @@ import hudson.model.Descriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author Kohsuke Kawaguchi
  * @see <a href="https://en.wikipedia.org/wiki/Flag_of_Tennessee">Tennessee state flag</a>
@@ -28,6 +30,7 @@ public class ThreeStars extends AbstractDescribableImpl<ThreeStars> {
     @Symbol("tennessee")
     public static class DescriptorImpl extends Descriptor<ThreeStars> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "Tri-star state";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/UnambiguousClassName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/UnambiguousClassName.java
@@ -29,6 +29,8 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousClassName> {
     public final String one;
 
@@ -40,6 +42,7 @@ public class UnambiguousClassName extends AbstractDescribableImpl<UnambiguousCla
     @Extension
     public static class DescriptorImpl extends Descriptor<UnambiguousClassName> {
         @Override
+        @Nonnull
         public String getDisplayName() {
                 return "An unambiguous describable";
             }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/SharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/first/SharedName.java
@@ -26,10 +26,11 @@ package org.jenkinsci.plugins.structs.describable.first;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.AbstractSharedName;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
 
 public class SharedName extends AbstractSharedName {
     private final String one;
@@ -66,6 +67,7 @@ public class SharedName extends AbstractSharedName {
     @Extension
     public static class DescriptorImpl extends Descriptor<AbstractSharedName> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "first.SharedName";
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/second/SharedName.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/second/SharedName.java
@@ -26,9 +26,10 @@ package org.jenkinsci.plugins.structs.describable.second;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.AbstractSharedName;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 public class SharedName extends AbstractSharedName {
     public final String two;
@@ -41,6 +42,7 @@ public class SharedName extends AbstractSharedName {
     @Extension
     public static class DescriptorImpl extends Descriptor<AbstractSharedName> {
         @Override
+        @Nonnull
         public String getDisplayName() {
             return "second.SharedName";
         }


### PR DESCRIPTION
This is in general just some code cleanup. The only thing is the replacing of 
>        Jenkins j = Jenkins.getInstance(); 
with
 >       Jenkins j = Jenkins.getInstanceOrNull();

I also added some **Nonnull** annotations for overrides, where applicable.

I'm not sure if the get() call would not be better, but I did not want to change behaviour.