### PR TITLE
Enable dependabot to automatically get dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
It would be great to have **Dependabot** configured to get dependencies updates filed automatically. This will help avoiding bugs or security vulnerabilities from old dependencies.

Some helpful documentation about Dependabot to fine adjust it if needed:

* Keeping your dependencies updated automatically: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically
* Avoiding security vulnerabilities: https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/configuring-github-dependabot-security-updates
* Fine adjusting the configuration: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

