### PR TITLE
Taking CustomDescribableModel out of beta

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/CustomDescribableModel.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/CustomDescribableModel.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -59,7 +57,6 @@ import org.kohsuke.stapler.DataBoundSetter;
  * <p>Arguments passed to customization methods are immutable.
  * If you wish to make changes, create and return a copy of the argument.
  */
-@Restricted(Beta.class)
 public interface CustomDescribableModel /* extends Descriptor */ {
 
     /**


### PR DESCRIPTION
#43 was released over a year and a half ago, used at least in

* https://github.com/jenkinsci/pipeline-input-step-plugin/blob/ea5fd3106431a081539ace0aa65512dcc2f75a39/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java#L176-L221
* https://github.com/jenkinsci/git-plugin/blob/f273d31f183105d17e37b3e6c1acf87a2782fa0c/src/main/java/hudson/plugins/git/UserMergeOptions.java#L167-L175
* https://github.com/jenkinsci/workflow-cps-global-lib-plugin/blob/1a9f8ae23743ad06fbc736b4562a5a8ae2395c1d/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java#L214-L225
* https://github.com/jenkinsci/pipeline-build-step-plugin/blob/9a85d3150a61536bfe6a6ca358cf16383ffd9c13/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java#L139-L175
* https://github.com/jenkinsci/github-branch-source-plugin/blob/490693b59b83a4a82b0b94dd1ba2c7b5870be005/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java#L1969-L1983
* https://github.com/cloudbees/cloudbees-workflow-template-plugin/blob/d9a189909c25474882d64b5642d560b3de55b50b/src/main/java/com/cloudbees/pipeline/governance/templates/TemplateCatalog.java#L942-L955 (proprietary)

Seems to make sense to treat it as official by now. Might help unblock https://github.com/jenkinsci/docker-workflow-plugin/pull/170.
