### PR TITLE
Use BOM, and adapt to a change in GitSCM behavior

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(useAci: true)

--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -24,25 +24,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>4.0.0-beta1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency><!-- JENKINS-28942 workaround -->
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
-      <version>1.17</version>
+      <version>4.6.0</version> <!-- TODO https://github.com/jenkinsci/bom/pull/431 -->
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/plugin/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.plugins.structs;
 
+import com.google.inject.Injector;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
 import hudson.model.Describable;
@@ -93,10 +95,11 @@ public class SymbolLookup {
             for (Class<?> e : Index.list(Symbol.class, pluginManager.uberClassLoader, Class.class)) {
                 if (type.isAssignableFrom(e)) {
                     Symbol s = e.getAnnotation(Symbol.class);
-                    if (s != null) {
+                    Injector injector = jenkins.getInjector();
+                    if (s != null && injector != null) {
                         for (String t : s.value()) {
                             if (t.equals(symbol)) {
-                                i = jenkins.getInjector().getInstance(e);
+                                i = injector.getInstance(e);
                                 cache.put(k, i);
                                 return type.cast(i);
                             }
@@ -198,11 +201,7 @@ public class SymbolLookup {
      * Gets the singleton instance.
      */
     public static SymbolLookup get() {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException();
-        }
-        return j.getInjector().getInstance(SymbolLookup.class);
+        return ExtensionList.lookupSingleton(SymbolLookup.class);
     }
 
     /**

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -658,8 +658,6 @@ public class DescribableModelTest {
             "extensions", Arrays.asList(map(CLAZZ, CleanBeforeCheckout.class.getSimpleName())),
             // Default values for these things do not work because GitSCM fails to use @DataBoundSetter:
             "branches", Arrays.asList(map("name", "*/master")),
-            "doGenerateSubmoduleConfigurations", false,
-            "submoduleCfg", Collections.emptyList(),
             "userRemoteConfigs", Collections.emptyList()));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>4.16</version>
     <relativePath />
   </parent>
 
@@ -37,9 +37,21 @@
   <properties>
     <revision>1.22</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.107.3</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>24</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <repositories>
     <repository>


### PR DESCRIPTION
Noticed in https://github.com/jenkinsci/bom/pull/431 that https://github.com/jenkinsci/git-plugin/pull/1043 broke a longstanding test here (which ultimately should probably be rewritten to use some mock describables). Switching to the BOM and just temporarily overriding the `git` plugin version. Supersedes #58, #73, #74, #76, and #77.
