### PR TITLE
Fix test for future versions of jenkins - PCT failures

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -36,6 +36,9 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserMergeOptions;
 import hudson.plugins.git.extensions.impl.CleanBeforeCheckout;
 import java.util.HashMap;
+
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.structs.Fishing;
@@ -647,9 +650,15 @@ public class DescribableModelTest {
     }
 
     @Test public void parametersDefinitionProperty() throws Exception {
-        roundTrip(ParametersDefinitionProperty.class, map("parameterDefinitions", Arrays.asList(
-                map(CLAZZ, "BooleanParameterDefinition", "name", "flag", "defaultValue", false),
-                map(CLAZZ, "StringParameterDefinition", "name", "text", "trim", false))));
+        if (Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.289"))) {
+            roundTrip(ParametersDefinitionProperty.class, map("parameterDefinitions", Arrays.asList(
+                    map(CLAZZ, "BooleanParameterDefinition", "name", "flag"),
+                    map(CLAZZ, "StringParameterDefinition", "name", "text"))));
+        } else {
+            roundTrip(ParametersDefinitionProperty.class, map("parameterDefinitions", Arrays.asList(
+                    map(CLAZZ, "BooleanParameterDefinition", "name", "flag", "defaultValue", false),
+                    map(CLAZZ, "StringParameterDefinition", "name", "text", "trim", false))));
+        }
     }
 
     @Issue("JENKINS-26619")

--- a/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/structs/describable/DescribableModelTest.java
@@ -650,7 +650,7 @@ public class DescribableModelTest {
     }
 
     @Test public void parametersDefinitionProperty() throws Exception {
-        if (Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.289"))) {
+        if (Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.281"))) {
             roundTrip(ParametersDefinitionProperty.class, map("parameterDefinitions", Arrays.asList(
                     map(CLAZZ, "BooleanParameterDefinition", "name", "flag"),
                     map(CLAZZ, "StringParameterDefinition", "name", "text"))));


### PR DESCRIPTION
Due to jenkinsci/jenkins#5275 a test breaks PCT and is blocking jenkinsci/bom#511.

Adapt the test to work for the plugin's version of jenkins and for the later releases of jenkins

Tested manually with `mvn clean install -Djenkins.version=2.289`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
