### PR TITLE
Test with Java 21

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.6</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,4 @@
-buildPlugin(useContainerAgent: true,
-        configurations: [
-                [platform: 'linux', jdk: '11'],
-                [platform: 'windows', jdk: '8'],
-
-                // testing the Guava & Guice bumps
-                // https://github.com/jenkinsci/jenkins/pull/5707
-                // https://github.com/jenkinsci/jenkins/pull/5858
-                [ platform: "linux", jdk: "8", jenkins: '2.321' ]
-        ])
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.289.x</artifactId>
-        <version>1289.v5c4b_1c43511b_</version>
+        <version>1478.v81d3dc4f9a_43</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.289.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.43.1</version>
+    <version>4.63</version>
     <relativePath />
   </parent>
 
@@ -33,7 +33,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -41,8 +41,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
-        <version>1478.v81d3dc4f9a_43</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2081.v85885a_d2e5c5</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/describable/DescribableModel.java
@@ -630,6 +630,7 @@ public final class DescribableModel<T> implements Serializable {
      * @deprecated as of 1.2
      *      Use {@link #uninstantiate2(Object)}
      */
+    @Deprecated
     public Map<String,Object> uninstantiate(T o) throws UnsupportedOperationException {
         return uninstantiate2(o).toMap();
     }
@@ -737,6 +738,7 @@ public final class DescribableModel<T> implements Serializable {
      *
      * @deprecated as of 1.2. Use {@link #uninstantiate2_(Object)}
      */
+    @Deprecated
     public static Map<String,Object> uninstantiate_(Object o) {
         return uninstantiate__(o, o.getClass());
     }


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.  The acceptance test harness and plugin bill of materials tests are already passing with Java 21.  This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The pull request also includes the contents of other pull requests that are needed in order to compile and test with Java 21.  Those pull requests include:

* #168
* #170
* #172
* #175

The pull request also annotates two deprecated methods with @Deprecated in order to silence a Java compiler warning.

### Testing done

Confirmed tests pass with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
