### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -41,8 +41,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2705.vf5c48c31285b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/SymbolLookup.java
@@ -15,7 +15,7 @@ import org.jenkinsci.Symbol;
 import org.jvnet.hudson.annotation_indexer.Index;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/structs/SymbolLookupTest.java
@@ -5,7 +5,7 @@ import hudson.model.BooleanParameterValue;
 import hudson.model.Descriptor;
 import java.util.Collections;
 import java.util.Set;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import jenkins.model.GlobalConfiguration;
 import static org.hamcrest.CoreMatchers.*;
 import org.jenkinsci.Symbol;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.