### PR TITLE
More robust subtype handling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
@@ -82,14 +82,14 @@ public abstract class ParameterType {
                         if (entry.getValue().size() == 1) { // normal case: unambiguous via simple name
                             try {
                                 types.put(entry.getKey(), DescribableModel.of(entry.getValue().get(0)));
-                            } catch (Exception x) {
+                            } catch (Exception | NoClassDefFoundError x) {
                                 LOGGER.log(Level.FINE, "skipping subtype", x);
                             }
                         } else { // have to diambiguate via FQN
                             for (Class<?> subtype : entry.getValue()) {
                                 try {
                                     types.put(subtype.getName(), DescribableModel.of(subtype));
-                                } catch (Exception x) {
+                                } catch (Exception | NoClassDefFoundError x) {
                                     LOGGER.log(Level.FINE, "skipping subtype", x);
                                 }
                             }

--- a/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
@@ -82,15 +82,19 @@ public abstract class ParameterType {
                         if (entry.getValue().size() == 1) { // normal case: unambiguous via simple name
                             try {
                                 types.put(entry.getKey(), DescribableModel.of(entry.getValue().get(0)));
-                            } catch (Exception | NoClassDefFoundError x) {
+                            } catch (Exception x) {
                                 LOGGER.log(Level.FINE, "skipping subtype", x);
+                            } catch (NoClassDefFoundError x) {
+                                LOGGER.log(Level.WARN, "skipping subtype", x);
                             }
                         } else { // have to diambiguate via FQN
                             for (Class<?> subtype : entry.getValue()) {
                                 try {
                                     types.put(subtype.getName(), DescribableModel.of(subtype));
-                                } catch (Exception | NoClassDefFoundError x) {
+                                } catch (Exception x) {
                                     LOGGER.log(Level.FINE, "skipping subtype", x);
+                                } catch (NoClassDefFoundError x) {
+                                    LOGGER.log(Level.WARN, "skipping subtype", x);
                                 }
                             }
                         }

--- a/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
@@ -83,18 +83,18 @@ public abstract class ParameterType {
                             try {
                                 types.put(entry.getKey(), DescribableModel.of(entry.getValue().get(0)));
                             } catch (Exception x) {
-                                LOGGER.log(Level.FINE, "skipping subtype", x);
+                                LOGGER.log(Level.FINE, x, () -> "skipping subtype " + entry.getValue(0).getName());
                             } catch (NoClassDefFoundError x) {
-                                LOGGER.log(Level.WARNING, "skipping subtype", x);
+                                LOGGER.log(Level.WARNING, x, () -> "skipping subtype " + entry.getValue(0).getName());
                             }
                         } else { // have to diambiguate via FQN
                             for (Class<?> subtype : entry.getValue()) {
                                 try {
                                     types.put(subtype.getName(), DescribableModel.of(subtype));
                                 } catch (Exception x) {
-                                    LOGGER.log(Level.FINE, "skipping subtype", x);
+                                    LOGGER.log(Level.FINE, x, () -> "skipping subtype " + subtype.getName());
                                 } catch (NoClassDefFoundError x) {
-                                    LOGGER.log(Level.WARNING, "skipping subtype", x);
+                                    LOGGER.log(Level.WARNING, x, () -> "skipping subtype " + subtype.getName());
                                 }
                             }
                         }

--- a/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
@@ -85,7 +85,7 @@ public abstract class ParameterType {
                             } catch (Exception x) {
                                 LOGGER.log(Level.FINE, "skipping subtype", x);
                             } catch (NoClassDefFoundError x) {
-                                LOGGER.log(Level.WARN, "skipping subtype", x);
+                                LOGGER.log(Level.WARNING, "skipping subtype", x);
                             }
                         } else { // have to diambiguate via FQN
                             for (Class<?> subtype : entry.getValue()) {
@@ -94,7 +94,7 @@ public abstract class ParameterType {
                                 } catch (Exception x) {
                                     LOGGER.log(Level.FINE, "skipping subtype", x);
                                 } catch (NoClassDefFoundError x) {
-                                    LOGGER.log(Level.WARN, "skipping subtype", x);
+                                    LOGGER.log(Level.WARNING, "skipping subtype", x);
                                 }
                             }
                         }

--- a/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
+++ b/src/main/java/org/jenkinsci/plugins/structs/describable/ParameterType.java
@@ -83,9 +83,9 @@ public abstract class ParameterType {
                             try {
                                 types.put(entry.getKey(), DescribableModel.of(entry.getValue().get(0)));
                             } catch (Exception x) {
-                                LOGGER.log(Level.FINE, x, () -> "skipping subtype " + entry.getValue(0).getName());
+                                LOGGER.log(Level.FINE, x, () -> "skipping subtype " + entry.getValue().get(0).getName());
                             } catch (NoClassDefFoundError x) {
-                                LOGGER.log(Level.WARNING, x, () -> "skipping subtype " + entry.getValue(0).getName());
+                                LOGGER.log(Level.WARNING, x, () -> "skipping subtype " + entry.getValue().get(0).getName());
                             }
                         } else { // have to diambiguate via FQN
                             for (Class<?> subtype : entry.getValue()) {


### PR DESCRIPTION
If a plugin is referencing classes that were removed from core, exploring all subtypes may cause `NoClassDefFoundError`s.
Since `Exception`s are already ignored, I'd like to suggest ignoring these errors as well, just with more prominent logging.

### Testing done

Tested through https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/570 to verify that loading faulty plugins does not completely break the pipeline step generator.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
